### PR TITLE
Flesh out readme and adapt files to help Contributors build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,231 @@
-Taxbrain Web Application
-========================
+# OSPC Webapp
+<!---
+  @todo Add code status indicators?
+    Possible services include codeclimate, travis, codeship, coveralls, inch-ci, hakiri
+    Examples:
+  [![Build Status](https://codeship.com/projects/0e40c6d0-4787-0132-ccf4-025f0fbdfe45/status?branch=master)](https://codeship.com/projects/0e40c6d0-4787-0132-ccf4-025f0fbdfe45)
+  [![Build Status](https://secure.travis-ci.org/angular-ui/bootstrap.svg)](http://travis-ci.org/angular-ui/bootstrap)
+  [![Code Climate](https://codeclimate.com/github/wellbredgrapefruit/asari.png)](https://codeclimate.com/github/wellbredgrapefruit/asari)
+  [![Security](https://hakiri.io/github/wellbredgrapefruit/asari/master.svg)](https://hakiri.io/github/wellbredgrapefruit/asari/master)
+  [![Test Coverage](https://img.shields.io/coveralls/resque/resque/master.svg)](https://coveralls.io/r/resque/resque)
+  [![Inline Doc Coverage](http://inch-ci.org/github/resque/resque.svg)](http://inch-ci.org/github/resque/resque)
+-->
+Webapp is a Python/Django-based web serving application for the Open Source
+  Policy Center. It serves static pages with information on the OSPC and
+  provides GUI access to its apps.
 
-# Deploying To Heroku
+* [Getting Started](#getting-started)
+  * [Requirements](#requirements)
+  * [Installation](#installation)
+  * [Database Setup](#database-setup)
+  * [Debug Flags](#set-debug-flags)
+  * [Bower](#bower)
+* [Running the App](#running-the-app)
+  * [Using Django](#using-django)
+  * [Using Foreman](#using-foreman)
+* [Making Changes](#making-changes)
+* [Deploying to Heroku](#deploying-to-heroku)
 
-Production
-----------
-Heroku relies upon GIT for deployment.  The following commands are for deployment.  Before deploying to Heroku make certain to run the following command* locally and commit the changes:
+<!---
+  @todo Add these items?
+* [Roadmap](#roadmap)
+* [Contributing](#contributing)
+* [License](#license)
+-->
 
-`./manage.py collectstatic --noinput`
+## Getting started
 
-###### * Currently this command fails to create the staticfiles dir on Heroku, so this has to be run locally and the changes committed.
+### Requirements
 
-Deploy to Heroku:
+To install and use Webapp you will need:
 
-`git push heroku master`
+* [Python](https://www.python.org/downloads/) - 2.7 or 3.4 is fine as it's just
+  used to build the Conda virtual environment where WebApp sets up its own 2.7
+  copy. However, you MUST use the x64 version, or else pandas will run out of
+  memory when importing tax data.
+* [Anaconda](http://continuum.io/downloads) or
+  [Miniconda](http://conda.pydata.org/miniconda.html)
 
-If any of the models have been updated in a deployment then those changes have to migrated so the database schema is updated.  The migration should be created locally, committed, and pushed to Heroku as opposed to running the makemigration command on Heroku.  Locally run the following:
+Additionally, if you will be making CSS or JS changes you will need:
 
-`./manage.py makemigrations` or `python manage.py makemigrations` (both commands have the same effect.)
+* [Bower](http://bower.io/) (which requires Node.js and NPM) for vendor files
+* A LESS compiler. Node's can be installed with `npm install less -g` and used
+  with `lessc path/to/source.lss > path/to/dest.css`
 
-Commit the files that are created.
+By default the application will use a SQLite database, which requires no
+  additional steps. However, if you'd like to use PostgreSQL you will need:
 
-In order to run those migrations, run the following commands:
-
-`heroku run ./manage.py migrate` or `heroku run python manage.py migrate` (both commands have the same effect.)
-
-Your schema will now be udpated.
-
-*DEBUG*:  This should always be False on the production site.  Make certain the environment variable DEV_DEBUG is set to anything but the string 'True'.  To check what variables are set to in Heroku's environment run the following command:
-
-`heroku config`
-
-This will list all config variables (alternatively go to the Settings section on the Heroku dashboard and click the 'Reveal Config Vars' button.)
-
-Development
------------
-A live development server works exactly the same way as a production server on Heroku does.  All commands and configurations are the same.  The only difference is that the requirements_dev.txt can be used on this server to have access to the various debugging tools.
-
-Post deployment to a dev server runt he following command in order to install the dev tools (if desired):
-`heroku run pip install -r requirement_dev.txt`
-
-The migration commands presented in the Production section also hold true for development.  Post deployment make sure to run the migration commands.
-
-*DEBUG*: In order to turn DEBUG on, set the DEV_DEBUG environment variable to the string 'True'.  DEBUG will be off id set to anything but 'True'.  In order to change the DEV_DEBUG variable use the following command:
-`heroku config:set DEV_DEBUG='True'`
-
-The above command will turn DEBUG on.  Setting to any other string will turn DEBUG off.
+* PostgreSQL database server: [OS X](http://www.postgresql.org/download/macosx/),
+   [Ubunutu](https://help.ubuntu.com/community/PostgreSQL),
+   [Windows](http://www.postgresql.org/download/windows/).
+* If you're on Windows, the Postgres adapter requires a couple more steps:
+  * It used to be possible to succeed in installing the psycopg2 library with
+  the below:
+    * add Postgres's bin folder to your path (i.e. C:\Devtools\PostgreSQL\9.4\bin)
+    * install the
+    [Microsoft Visual C++ Compiler for Python](http://www.microsoft.com/en-us/download/details.aspx?id=44266)
+    to compile some supporting libraries distributed as source
+  * Now, until [this issue](https://github.com/nwcell/psycopg2-windows/issues/4)
+  is fixed, you must instead follow these steps:
+    * Install a copy of Python 2.7 to your PATH (needed for below installer)
+    * Install Windows pre-compiled binaries from
+    [here](http://www.stickpeople.com/projects/python/win-psycopg/)
+    * Move the resulting folder into your conda env
+    * Remove the explicit psycopg2 line from `requirements.txt`; it will never
+    validate but you should be able to use the library.
+    * Ensure to add local gitignore to `requirements.txt` since you've changed it.
 
 
-# Installing Locally
+### Installation
 
-## Installing PostgreSQL
-Postgres is used for this project.  If PostgreSQL is not installed on your machine follow the instructions in the following links.
+#### Clone the repo into a new directory
+Navigate to your web projects directory and use git to clone the project files
+into a new directory:
 
-OS X:
-http://www.postgresql.org/download/macosx/
-
-Ubunutu:
-https://help.ubuntu.com/community/PostgreSQL
-
-Windows (should support 7 & 8):
-http://www.postgresql.org/download/windows/
-
-## Create database taxcalc
-After PostgreSQL has been successfully installed make sure to create the taxcalc database.
-
-For Ubuntu the command is:
-```
-createdb taxcalc
-```
-
-If you need to add a user and grant permissions make sure to have psql installed as well.
-
-## Create a directory
-Make sure to create a directory wherever you keep your projects.
-
-```
-mkdir project_name
-```
-
-## Clone the repo in the new directory
-
+via SSH
 ```
 git clone git@github.com:OpenSourcePolicyCenter/webapp.git
 ```
 
-## Create a conda environment for your local development
-
+or via HTTPS
 ```
-conda create -n webapp pip python=2.7
-source activate webapp
+git clone https://github.com/OpenSourcePolicyCenter/webapp
 ```
 
-Install the required packages listed in the conda-requirements.txt file:
+#### Use Conda to install libraries
+
+Conda manages a virtual environment of python libraries and sources. The files
+  `.condarc` and `conda-requirements` are used by the Heroku Conda buildpack to
+  accomplish this on Herkou servers. Locally, you should use the provided
+  `environment.yml` instead:
+
+* Create a conda environment and load this project's dependencies
+  * `conda env create` (Note it will detect `environment.yml` automatically, but
+  for future reference you can specify alternative environment files with
+  `conda env create --file filename.yml`)
+* Tell Conda to use it for our current session
+  * `source activate ospc-webapp-public` (or simply `activate ospc-webapp-public` on Windows)
+* If you ever need to deactivate it, you can use
+  * `source deactivate` (`deactivate` on Windows)
+
+##### Updating Conda Packages
+Occasionally you will need to update conda's packages. Do this by activating your
+environment, then `conda env update`.
+
+
+#### Use Pip to install more libraries
+
+Now that Conda has set up our virtual environment and downloaded Pip, we can use
+  Pip to install the packages which Conda doesn't support directly into our
+  environment.
 
 ```
-conda install --file conda-requirements.txt
-```
-
-Some of the packages are listed in a requirements.txt, which uses pip. Install pip:
-
-```
-conda install pip
-```
-
-Then use pip to install the remaining packages
-
-```
-pip install -r requirements.txt
-```
-
-then:
-
-```
+pip install -r requirements_nopsycopg.txt
 pip install -r requirements_dev.txt
 ```
 
-## Using foreman
-Since Django can be a more involved process using foreman might be a better tool for some situations.  If no work will be done on the back end, then foreman might be the tool of choice (although once Django is setup all you will have to do is run the server locally to make use of it.)
+If you'd like to use PostgreSQL, instead use:
+
+```
+pip install -r requirements.txt
+pip install -r requirements_dev.txt
+```
+
+#### Updating Pip libraries
+
+```
+pip install --upgrade -r requirements_nopsycopg.txt
+pip install --upgrade -r requirements_dev.txt
+```
+
+Similarly for Postgres you would drop the "_nopsycopg" above.
+
+
+### Database Setup
+
+Webapp requires a database. By default this will be automatically set up and
+configured by SQLite.
+
+If you'd prefer to use Postgres:
+
+* Set an environment variable `DATABASE_URL` in this format:
+  * `os.environ['DATABASE_URL'] = 'postgres://user:password@localhost:port/dbname'`
+* Then, create the taxcalc database on your PostgreSQL server and set up user
+  permissions to match `settings.py`.
+  * In Ubuntu you can create the database with `createdb taxcalc`. If you need to
+  add a user and grant permissions make sure to have psql installed.
+  * In Windows, use the pgAdmin tool.
+
+
+#### Run migrations
+Migrations manage the schema for all database objects. Ensure your Conda
+environment is activated, then simply run
+
+`python manage.py migrate`
+
+from the repo root. Django will then run the migrations to create all the db tables.
+
+*NOTE: After updating models, it is critical you rerun migrations. Otherwise, the
+changes will not be recognized and errors will be thrown by Django
+(these errors tend to be increasingly informative and you will usually be
+prompted by Django that there are unmigrated changes when you run the local
+server.)*
+
+
+#### Create Superuser
+You'll want an initial user with full privileges to navigate the backend.
+
+`python manage.py createsuperuser`
+
+This will prompt you interactively for a username and password.
+
+#### Load initial data
+Currently there is no seed data included in the application. If it's eventually
+included, you can run
+
+`python manage.py loaddata /full/path/to/data.json`
+
+To include it into the database. This is meant to be loadable as a "fixture" as
+well via Django, but we haven't been able to get that to work yet.
+
+### Set debug flags
+You'll likely want the DEV_DEBUG environment variable to the string 'True'
+ before running the application.
+
+### Bower
+
+To make CSS or JS changes, you'll need to first download the latest version of
+the vendor files with `bower install`.
+
+Subsequent updates can be made with `bower update`.
+
+## Running the App
+
+### Using Django
+Once all the dependencies are installed and settings configured you can start
+the server with
+
+`python manage.py runserver`
+
+Now you have a live project running locally!
+
+### Running dropQ
+dropQ workers are required to run the tax calculator. Start them according to
+dropQ's readme. To connect your workers to this webapp, set the environment
+variable `DROPQ_WORKERS` to a comma-delineated list of worker addresses, e.g.
+`DROPQ_WORKERS=localhost:5050`.
+
+### Using foreman
+Since Django can be a more involved process using foreman might be a better tool
+for some situations.  If no work will be done on the back end,
+then foreman might be the tool of choice (
+although once Django is setup all you will have to do is run the server
+locally to make use of it.)
 
 Some important points:
 - You must start the virtual environment.
-- The Heroku toolbar that is installed with the requirements.txt file is expecting PostgreSQL to exist on your system.
+- The Heroku toolbar that is installed with the requirements.txt file is
+expecting PostgreSQL to exist on your system.
 
 After the environment is activated the following command will start foreman:
 ```
@@ -129,44 +233,37 @@ foreman start
 ```
 Once the server has started foreman will use port 5000.
 
-## Using Django
-Once all the dependecies are installed a couple of commands are necessary to get the Django project up and running and onto ```./manage.py runserver```.  Make sure the virtual environment is activated.
+## Making Changes
 
-### First update the settings.py file located in the webapp dir (webapp/settings.py)
-In the settings.py file there is a database configuration that looks like:
+### CSS & JS
 
-```
-DATABASES = {
-'default': {
-    'ENGINE': 'django.db.backends.postgresql_psycopg2',
-    'NAME': 'taxcalc',
-    'USER': 'postgres',
-    'PASSWORD': '',
-    'HOST': '',
-    'PORT': '5432',
-    }
-}
-```
-1) Change the USER to your user name (the one you used to setup Postgres).
-2) Change the PASSWORD to the password you used to setup Postgres.
-3) Change HOST to 127.0.0.1
+CSS changes must be made to the LESS source files in `static/less` and then
+manually compiled to `static/css`, i.e. by running
+`lessc static/less/taxbrain.lss > static/css/taxbrain.css`.
 
-# PLEASE DO NOT COMMIT YOUR LOCAL CHANGES TO THE DATABASE CONFIG IN THE SETTINGS FILE.  GIT STASH THEM! 
-## ALTERNATIVELY, STOP TRACKING LOCAL CHANGES TO THIS FILE WITH:
-## `git update-index --assume-unchanged webapp/settings.py`
+CSS and JS changes will not be reflected until their source versions from
+`static` are moved to the deployed asset folder `staticfiles` with the command
+`python manage.py collectstatic`.
 
-Next change the DEBUG & TEMPLATE_DEBUG settings to True.
+There are asset pipelining solutions available for Django that would make the
+above steps unneccesary, but we have not yet implemented them.
 
-### Second migrations have to been run.  Migrations manage the schema for all database objects.  Go to the root of the project simply run:
-```
-./manage.py migrate
-```
-Django will then run the migrations and all the tables will be created in the db.  NOTE: it is critical that migrations are run when updating models, otherwise the changes to the models will not be recognized and errors will be thrown by Django (these errors tend to be increasingly informative and you will usually be prompted by Django that there are unmigrated changes when you run the local server.)
+## Deploying To Heroku
 
-### Third, it's time run the server.  Simply run:
-```
-./manage.py runserver
-```
+### Local pre-deployment tasks
 
-Now you have a live project being run locally!
+Before deploying to Heroku make certain to run the following command locally
+and commit the changes:
 
+`./manage.py collectstatic --noinput`
+
+Currently this command fails to create the staticfiles dir on Heroku,
+so this has to be run locally and the changes committed.
+
+### Pushing with Git
+
+Heroku relies upon GIT for deployment.
+
+Deploy to Heroku:
+
+`git push heroku master`

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,11 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "^3.3.6"
+    "bootstrap": "^3.3.6",
+    "html5shiv": "~3.7.2",
+    "moment": "~2.7.0"
+  },
+  "devDependencies": {
+    "respond": "~1.4.2"
   }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: ospc-webapp-public
+channels:
+  - https://conda.binstar.org/ospc
+  - defaults
+dependencies:
+  - pip
+  - python>=2.7
+  - numba
+  - taxcalc
+  - reportlab
+  - boto
+  - gevent
+  - pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,14 @@ Django==1.8.2
 argparse==1.2.1
 dj-database-url==0.3.0
 dj-static==0.0.6
-django-toolbelt==0.0.1
+#django-toolbelt==0.0.1 # requires psycopg
+gunicorn==19.1.1
 waitress
 static3==0.5.1
-wsgiref==0.1.2
+#wsgiref==0.1.2 #only need for python < 3.3
 -e git+https://github.com/funkybob/django-flatblocks.git#egg=django-flatblocks
 djrill
-psycopg2==2.5.4
+#psycopg2==2.5.4 # not easily compatible with windows
 django-user-accounts
 django-uuidfield==0.5.0
 django-queryset-csv==0.2.10
@@ -26,3 +27,5 @@ requests_mock
 boto
 django-storages
 django-htmlmin
+git+https://github.com/OpenSourcePolicyCenter/dropq.git
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ django-debug-toolbar==1.2.1
 ipdb==0.8
 ipython==2.2.0
 yolk==0.4.3
+git+https://github.com/OpenSourcePolicyCenter/Tax-Calculator

--- a/webapp/apps/pages/urls.py
+++ b/webapp/apps/pages/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, include, url
 
-from views import homepage, aboutpage, newspage, newsdetailpage
+from .views import homepage, aboutpage, newspage, newsdetailpage
 
 
 urlpatterns = patterns('',

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -12,7 +12,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 import os
 
-SECRET_KEY = os.environ.get('SECRET_KEY', '')
+SECRET_KEY = os.environ.get('SECRET_KEY', 'default_secret_key')
 
 # Allow all host headers
 ALLOWED_HOSTS = ['*']
@@ -146,7 +146,7 @@ DEFAULT_FILE_STORAGE = "storages.backends.s3boto.S3BotoStorage"
 # Amazon S3 settings.
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ID", "")
-AWS_STORAGE_BUCKET_NAME = os.environ["AWS_STORAGE_BUCKET_NAME"]
+AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME", "")
 AWS_S3_HOST = os.environ.get("AWS_S3_HOST", None)
 
 # Tell django-storages that when coming up with the URL for an item in S3 storage, keep
@@ -171,7 +171,7 @@ if DEBUG:
 else:
     STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
-MANDRILL_API_KEY=os.environ.get('MANDRILL_API_KEY')
+MANDRILL_API_KEY=os.environ.get('MANDRILL_API_KEY', 'default_mandrill_key')
 EMAIL_BACKEND = 'djrill.mail.backends.djrill.DjrillBackend'
 BLOG_URL = os.environ.get('BLOG_URL', 'http://news.ospc.org/')
 


### PR DESCRIPTION
This PR includes a number of changes to make it easier for outside contributors to work with the project. With these changes, contributors should be able to follow the Readme and get this set up in < 5 minutes.
- Significant rewrite of `README.md` that walks users through initial local configuration and includes a lot of notes from my trials and tribulations getting it running. I've updated this to the latest build, which simplifies the database setup nicely. :smile: 
- Remove `dropq` requirements in `webapp.views` and `webapp.helpers`. There still remain some references in `webapp.tasks` - I haven't actually tackled running the worker on this public version yet, that will be next.
- Add > 0 length string defaults for `MANDRILL_API_KEY` and `SECRET_KEY` so the server will start without them supplied.
- Add an `environment.yml` so `conda env [create|update]` can be run without a file argument.
- Add a version of the requirements file `requirements_nopsycopg.txt` that leaves out the `psycopg2` requirement as well as `django-toolbelt==0.0.1` which also requires psycopg2. I was unsure of the best way to do this - I know the requirements file is used by the production build, so I didn't want to change it. I could instead drop it all in `requirements_dev.txt` and instruct new contributors to simply pip install that one file, but it didn't feel right since not everyone running this for development will only want to use SQLite. IMO any additional requirements that exist only for OSPC's production building and deployment should probably be left out of the main requirements files, but I'm not very close to the process for that so I'll that as something for you guys to ponder.
- Gitignore the `src` folder left behind by Pip when installing django-flatblocks.

@talumbau @MattHJensen Please let me know what I should change/fix!
