### PR TITLE
Fix 'Edit Parameters' button on results page

### DIFF
--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -65,7 +65,7 @@
 
     <div class="result-table">
       <div class="result-table-controls">
-        <a href="/taxbrain/" class="btn btn-secondary">Edit Parameters</a>
+        <a href="/taxbrain/edit/{{ unique_url.pk }}"" class="btn btn-secondary">Edit Parameters</a>
         <div class="controls-tools">
           <div class="btn-group">
             <button type="button" class="btn btn-text btn-sm dropdown-toggle" data-toggle="dropdown" aria-expanded="false">

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -328,6 +328,7 @@ class OutputUrl(models.Model):
     """
     unique_inputs = models.ForeignKey(TaxSaveInputs, default=None)
     user = models.ForeignKey(User, null=True, default=None)
+    model_pk = models.IntegerField(default=None, null=True)
     uuid = UUIDField(auto=True, default=None, null=True)
     taxcalc_vers = models.CharField(blank=True, default=None, null=True,
         max_length=50)

--- a/webapp/apps/taxbrain/urls.py
+++ b/webapp/apps/taxbrain/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, include, url
 
-from .views import personal_results, tax_results, output_detail, csv_input, csv_output, pdf_view
+from .views import personal_results, tax_results, output_detail, csv_input, csv_output, pdf_view, edit_personal_results
 
 
 urlpatterns = patterns('',
@@ -11,4 +11,5 @@ urlpatterns = patterns('',
     url(r'^pdf/$', pdf_view),
     # Redirect for temporary page.
     url(r'^processing/(?P<pk>\d+)/', tax_results, name='tax_results'),
+    url(r'^edit/(?P<pk>\d+)/', edit_personal_results, name='edit_personal_results'),
 )

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -80,6 +80,36 @@ def personal_results(request):
 
     return render(request, 'taxbrain/input_form.html', init_context)
 
+
+@permission_required('taxbrain.view_inputs')
+def edit_personal_results(request, pk):
+    """
+    This view handles the editing of previously entered inputs
+    """
+    try:
+        url = OutputUrl.objects.get(pk=pk)
+    except:
+        raise Http404
+
+    model = TaxSaveInputs.objects.get(pk=url.model_pk)
+    #Get the user-input from the model in a way we can render
+    ser_model = serializers.serialize('json', [model])
+    user_inputs = json.loads(ser_model)
+    inputs = user_inputs[0]['fields']
+
+    form_personal_exemp = PersonalExemptionForm(
+                        initial=inputs)
+
+    init_context = {
+        'form': form_personal_exemp,
+        'params': TAXCALC_DEFAULT_PARAMS,
+        'taxcalc_version': taxcalc_version,
+    }
+
+    return render(request, 'taxbrain/input_form.html', init_context)
+
+
+
 @permission_required('taxbrain.view_inputs')
 def tax_results(request, pk):
     """
@@ -97,6 +127,7 @@ def tax_results(request, pk):
         current_user = User.objects.get(pk=request.user.id)
         unique_url = OutputUrl()
         unique_url.unique_inputs = model
+        unique_url.model_pk = model.pk
         unique_url.user = current_user
         unique_url.save()
 


### PR DESCRIPTION
- Adds new view 'taxbrain/edit/{id}. We go back to the database
  to get the model parameters and then populate the input screen
  based on that. This avoids any issues with storing input info
  in the session, which we previously had a problem with.