### PR TITLE
remove dependency on dropq to run webserver

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 import taxcalc
-import dropq
 import os
 import requests
 from requests.exceptions import Timeout, RequestException
@@ -8,6 +7,11 @@ import json
 import pandas as pd
 import time
 
+try:
+    import dropq
+    dropq_available = True
+except ImportError:
+    dropq_available = False
 
 #
 # Prepare user params to send to DropQ/Taxcalc
@@ -16,8 +20,11 @@ import time
 tcversion_info = taxcalc._version.get_versions()
 taxcalc_version = ".".join([tcversion_info['version'], tcversion_info['full'][:6]])
 
-dqversion_info = dropq._version.get_versions()
-dropq_version = ".".join([dqversion_info['version'], dqversion_info['full'][:6]])
+if dropq_available:
+    dqversion_info = dropq._version.get_versions()
+    dropq_version = ".".join([dqversion_info['version'], dqversion_info['full'][:6]])
+else:
+    dropq_version = 0
 
 NUM_BUDGET_YEARS = int(os.environ.get('NUM_BUDGET_YEARS', 10))
 START_YEAR = int(os.environ.get('START_YEAR', 2015))
@@ -76,7 +83,12 @@ TAXCALC_RESULTS_DFTABLE_COL_FORMATS = [
     [         1,   '%', 1],  # "%age Tax Decrease",
     [         1,   '%', 1],  # "Share of Overall Change"
 ]
-TAXCALC_RESULTS_BIN_ROW_KEYS = dropq.dropq.bin_row_names
+TAXCALC_RESULTS_BIN_ROW_KEYS = [
+    "less_than_10", "ten_twenty", "twenty_thirty", "thirty_forty",
+    "forty_fifty", "fifty_seventyfive", "seventyfive_hundred",
+    "hundred_twohundred", "twohundred_fivehundred",
+    "fivehundred_thousand", "thousand_up", "all"
+]
 TAXCALC_RESULTS_BIN_ROW_KEY_LABELS = {
     'less_than_10':'Less than 10',
     'ten_twenty':'10-20',
@@ -91,7 +103,11 @@ TAXCALC_RESULTS_BIN_ROW_KEY_LABELS = {
     'thousand_up':'1000+',
     'all':'All'
 }
-TAXCALC_RESULTS_DEC_ROW_KEYS = dropq.dropq.decile_row_names
+TAXCALC_RESULTS_DEC_ROW_KEYS = [
+    "perc0-10", "perc10-20", "perc20-30", "perc30-40",
+    "perc40-50", "perc50-60", "perc60-70", "perc70-80",
+    "perc80-90", "perc90-100", "all"
+]
 TAXCALC_RESULTS_DEC_ROW_KEY_LABELS = {
     'perc0-10':'0-10%',
     'perc10-20':'10-20%',

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -2,7 +2,6 @@ import csv
 import pdfkit
 import json
 import taxcalc
-import dropq
 import datetime
 
 from django.core import serializers


### PR DESCRIPTION
These changes are required for a public contributor (who would not have access to `dropq`) to successfully run the web application. Without them, python will throw import errors.

**Public contributors are not able to run the calculator job**
Note that this does not enable a contributor to run the calculator to support submissions of the taxbrain inputs form - I'm not sure what the plan was to tackle that, but it's pretty involved and will likely require some standardization between the output formats from `dropq` and `taxcalc`.

**Statically defined results format**
`TAXCALC_RESULTS_BIN_ROW_KEYS` and `TAXCALC_RESULTS_DEC_ROW_KEYS ` are now statically defined instead of pulled from `dropq`. The definitions are pulled directly from the current version of `dropq`, so should work fine. This would remove our ability to change the output format in `dropq` and have it automatically picked up in `webapp`, except we never actually had that ability: the label variables already statically define their keys. We could make this conditional on the added `dropq_available` variable and if it's available import all the results keys and labels dynamically, but I think the answer to the above issue about running the calculator will probably change how these labels and keys are stored and managed. So for right now this seems appropriate.

