### PR TITLE
Removing Medicare sections

### DIFF
--- a/templates/taxbrain/includes/params/inputs/other_taxes.html
+++ b/templates/taxbrain/includes/params/inputs/other_taxes.html
@@ -17,11 +17,6 @@
 {% include 'taxbrain/includes/params/inputs/param.html' with param=params.NIIT_thd %}
 {% include 'taxbrain/includes/params/inputs/param.html' with param=params.NIIT_trt %}
 
-<h2>Additional Medicare Tax</h2>
-{% include 'taxbrain/includes/params/inputs/param.html' with param=params.AMED_thd %}
-{% include 'taxbrain/includes/params/inputs/param.html' with param=params.AMED_trt %}
-
-
 {% endblock %}
 
 {% block next_section_shortname %}refundable-credits{% endblock %}

--- a/templates/taxbrain/includes/params/inputs/soc.html
+++ b/templates/taxbrain/includes/params/inputs/soc.html
@@ -1,20 +1,19 @@
 {% extends 'taxbrain/input_form_section.html' %}
 
 {% block input_section_shortname %}social-medicare{% endblock %}
-{% block input_section_title %}Social Security and Medicare{% endblock %}
+{% block input_section_title %}Social Security Taxability{% endblock %}
 
 {% load flatblocks %}
 
 {% block content %}
 <div class="inputs-block-header">
-  <h1>Social Security and Medicare</h1>
+  <h1>Social Security Taxability</h1>
   {% flatblock "taxbrain_socsec_blurb" %}
   {% block section_warnings %}
   {% endblock %}
 </div>
 
 <h2>Social Security Taxability</h2>
-{% include 'taxbrain/includes/params/inputs/param.html' with param=params.SS_Earnings_c %}
 {% include 'taxbrain/includes/params/inputs/param.html' with param=params.SS_thd50 %}
 {% include 'taxbrain/includes/params/inputs/param.html' with param=params.SS_percentage1 %}
 {% include 'taxbrain/includes/params/inputs/param.html' with param=params.SS_thd85 %}

--- a/templates/taxbrain/input_form.html
+++ b/templates/taxbrain/input_form.html
@@ -46,7 +46,7 @@
       <div class="inputs-sidebar">
         <ul class="nav sidebar-nav">
           <li class="get-started"><a href="#get-started">Get Started</a></li>
-          <li><a href="#social-medicare">Social Security and Medicare</a></li>
+          <li><a href="#social-medicare">Social Security Taxability</a></li>
           <li><a href="#adjustments">Adjustments</a></li>
           <li><a href="#exemptions">Exemptions</a></li>
           <li><a href="#standard-deduction">Standard Deduction</a></li>

--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -47,6 +47,9 @@ def string_to_float_array(s):
     else:
         return []
 
+def same_version(v1, v2):
+    idx = v1.rfind('.')
+    return v1[:idx] == v2[:idx]
 
 #
 # Prepare user params to send to DropQ/Taxcalc
@@ -938,7 +941,7 @@ def dropq_get_results(job_ids):
             print msg
             raise IOError(msg)
         versions = [r.get('dropq_version', None) for r in ans]
-        if not all([ver==dropq_version for ver in versions]):
+        if not all([same_version(ver, dropq_version) for ver in versions]):
             msg ="Got different dropq versions from workers. Bailing out"
             print msg
             raise IOError(msg)


### PR DESCRIPTION
- Remove Additional Medicare from the other taxes section
- Remove the max taxable earnings for Social Security from the Social
  Security and Medicare section
- Rename the Social Security and Medicare section to Social Security
  Taxability