### PR TITLE
Remove job IDs from session - store on model

### DIFF
--- a/webapp/apps/taxbrain/migrations/0011_taxsaveinputs_job_ids.py
+++ b/webapp/apps/taxbrain/migrations/0011_taxsaveinputs_job_ids.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import webapp.apps.taxbrain.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taxbrain', '0010_auto_20151016_0302'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='taxsaveinputs',
+            name='job_ids',
+            field=webapp.apps.taxbrain.models.SeparatedValuesField(default=None, null=True, blank=True),
+        ),
+    ]

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -50,6 +50,29 @@ class CommaSeparatedField(models.CharField):
         return name, path, args, kwargs
 
 
+class SeparatedValuesField(models.TextField):
+    __metaclass__ = models.SubfieldBase
+
+    def __init__(self, *args, **kwargs):
+        self.token = kwargs.pop('token', ',')
+        super(SeparatedValuesField, self).__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        if not value: return
+        if isinstance(value, list):
+            return value
+        return value.split(self.token)
+
+    def get_db_prep_value(self, value, connection, prepared=False):
+        if not value: return
+        assert(isinstance(value, list) or isinstance(value, tuple))
+        return self.token.join([unicode(s) for s in value])
+
+    def value_to_string(self, obj):
+        value = self._get_val_from_obj(obj)
+        return self.get_db_prep_value(value)
+
+
 class TaxSaveInputs(models.Model):
     """
     This model contains all the parameters for the tax model and the tax
@@ -308,6 +331,9 @@ class TaxSaveInputs(models.Model):
     growth_choice = models.CharField(blank=True, default=None, null=True,
                                      max_length=50)
 
+
+    # Job IDs when running a job
+    job_ids = SeparatedValuesField(blank=True, default=None, null=True)
 
     # generate fields from default param data
     # this may eventually be useful if we're able to ensure syncdb picks up


### PR DESCRIPTION
- Job IDs for processing jobs are moved from the session to being stored
  on the model. This allows the user to run multiple jobs in different
  tabs in the browser. W/o this, the different jobs in different browser
  tabs would conflict and all tabs would get the same completed job.

  This fix will cause more queries to the database, but it's the most
  correct way to handle processing jobs