### PR TITLE
Minor edits

### DIFF
--- a/templates/dynamic/behavior.html
+++ b/templates/dynamic/behavior.html
@@ -65,7 +65,7 @@
 
         <div id="get-started" class="inputs-block inputs-block-intro">
           <div class="inputs-block-header">
-            <h1>Partial Equilibrium Dynamic Simulation</h1>
+            <h1>Partial Equilibrium Simulation</h1>
            {% flatblock "dynamic_behavior_get_started_blurb" %}
             <div>
               You are looking at default parameters for {{start_year}}.

--- a/templates/dynamic/behavior.html
+++ b/templates/dynamic/behavior.html
@@ -48,7 +48,7 @@
         </ul>
         <div class="sidebar-button">
           <a href="#" ></a>
-          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Macro Simulation!">
+          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Dynamic Simulation!">
         </div>
       </div> <!-- sidebar -->
 

--- a/templates/dynamic/dynamic_input_form.html
+++ b/templates/dynamic/dynamic_input_form.html
@@ -49,7 +49,7 @@
         </ul>
         <div class="sidebar-button">
           <a href="#" ></a>
-          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Macro Simulation!">
+          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Dynamic Simulation!">
         </div>
       </div> <!-- sidebar -->
 

--- a/templates/dynamic/elasticity.html
+++ b/templates/dynamic/elasticity.html
@@ -44,7 +44,7 @@
       <div class="inputs-sidebar">
         <ul class="nav sidebar-nav">
           <li class="get-started"><a href="#get-started">Get Started</a></li>
-          <li><a href="#behavior">Elasticity of GDP</a></li>
+          <li><a href="#behavior">Elasticity of GDP wrt AMTR</a></li>
         </ul>
         <div class="sidebar-button">
           <a href="#" ></a>
@@ -65,7 +65,7 @@
 
         <div id="get-started" class="inputs-block inputs-block-intro">
           <div class="inputs-block-header">
-            <h1>Elasticity of GDP wrt Ave. Marginal Tax Rates</h1>
+            <h1>Macroeconomic Elasticities</h1>
            {% flatblock "dynamic_elasticity_get_started_blurb" %}
             <div>
               You are looking at default parameters for {{start_year}}.

--- a/templates/dynamic/elasticity.html
+++ b/templates/dynamic/elasticity.html
@@ -48,7 +48,7 @@
         </ul>
         <div class="sidebar-button">
           <a href="#" ></a>
-          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Macro Simulation!">
+          <input id="tax-submit" class="btn btn-secondary btn-block btn-animate" type="submit" value="Start Dynamic Simulation!">
         </div>
       </div> <!-- sidebar -->
 

--- a/templates/dynamic/landing.html
+++ b/templates/dynamic/landing.html
@@ -61,7 +61,7 @@
                 <table style="width:100%">
                 <tr padding="15px">
                     <td padding-bottom="1em">
-                    <a href="/dynamic/behavioral/{{pk}}/?start_year={{start_year}}" class="text-white btn btn-secondary">Partial Equilibrium Macro Simulation</a>
+                    <a href="/dynamic/behavioral/{{pk}}/?start_year={{start_year}}" class="text-white btn btn-secondary">Partial Equilibrium Simulation</a>
                     </td>
                     <td>
                       {% flatblock "dynamic_behavioral_blurb" %}

--- a/webapp/apps/dynamic/helpers.py
+++ b/webapp/apps/dynamic/helpers.py
@@ -152,7 +152,7 @@ def default_behavior_parameters(first_budget_year):
 def default_elasticity_parameters(first_budget_year):
     ''' Create a list of default Elasticity parameters '''
     default_elasticity_params = {}
-    default_value = 0.54
+    default_value = 0.0
     adj_long_name = ("Elasticity of GDP with respect to 1 - average marginal "
                      "tax rate.")
     adj_descr = ("The default value of {0} is from a 2011 paper by Barro "

--- a/webapp/apps/dynamic/helpers.py
+++ b/webapp/apps/dynamic/helpers.py
@@ -30,7 +30,7 @@ OGUSA_RESULTS_TOTAL_ROW_KEY_LABELS = {n:n for n in OGUSA_RESULTS_TOTAL_ROW_KEYS}
 
 ELASTIC_RESULTS_TOTAL_ROW_KEY_LABELS = {n:'% Difference in GDP' for n in ELASTIC_RESULTS_TOTAL_ROW_KEYS}
 ELASTIC_RESULTS_TABLE_LABELS = {
-        'elasticity_gdp': 'Elasticity of GDP wrt Average Marginal Tax Rate'
+        'elasticity_gdp': 'Elasticity of GDP wrt 1 - Average Marginal Tax Rate'
         }
 
 OGUSA_RESULTS_TABLE_LABELS = {
@@ -153,7 +153,7 @@ def default_elasticity_parameters(first_budget_year):
     ''' Create a list of default Elasticity parameters '''
     default_elasticity_params = {}
     default_value = 0.54
-    adj_long_name = ("Elasticity of GDP with respect to average marginal "
+    adj_long_name = ("Elasticity of GDP with respect to 1 - average marginal "
                      "tax rate.")
     adj_descr = ("The default value of {0} is from a 2011 paper by Barro "
                  "and Redlick".format(default_value))

--- a/webapp/apps/dynamic/helpers.py
+++ b/webapp/apps/dynamic/helpers.py
@@ -155,8 +155,10 @@ def default_elasticity_parameters(first_budget_year):
     default_value = 0.0
     adj_long_name = ("Elasticity of GDP with respect to 1 - average marginal "
                      "tax rate.")
-    adj_descr = ("The default value of {0} is from a 2011 paper by Barro "
-                 "and Redlick".format(default_value))
+    adj_descr = ("This parameter describes how many percent GDP will change "
+                 "for each 1 percent change in 1 - the average "
+                 "marginal tax rate, weighted by wage income, in the "
+                 "preceeding year.")
 
     elasticity_of_gdp = {'value':[default_value], 'col_label':"",
                          'long_name': adj_long_name,


### PR DESCRIPTION
- rename the partial equilibrium simulation.
- change "start macro simulation" buttons to "start dynamic simulation"
- note that the GDP elasticity is wrt 1-AMTR instead of AMTR after https://github.com/OpenSourcePolicyCenter/dropQ/pull/47
- update the default GDP macro elasticity rate from 0.54 to 0.0 per #174 
- update the information 'i' text for the gdp macro elasticity to reflect the change in the previous point. 

cc @talumbau @mistakevin 