### PR TITLE
Only read JSON response after checking status code

### DIFF
--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -84,10 +84,10 @@ class DropqCompute(object):
                 theurl = url_template.format(hn=hostnames[hostname_idx])
                 try:
                     response = self.remote_submit_job(theurl, data=data, timeout=TIMEOUT_IN_SECONDS)
-                    response_d = response.json()
                     if response.status_code == 200:
                         print "submitted: ", hostnames[hostname_idx]
                         year_submitted = True
+                        response_d = response.json()
                         job_ids.append((response_d['job_id'], hostnames[hostname_idx]))
                         hostname_idx = (hostname_idx + 1) % num_hosts
                         if response_d['qlength'] > max_queue_length:
@@ -274,3 +274,31 @@ class MockFailedCompute(MockCompute):
         with requests_mock.Mocker() as mock:
             mock.register_uri('GET', '/dropq_query_result', text='FAIL')
             return DropqCompute.remote_results_ready(self, theurl, params)
+
+class NodeDownCompute(MockCompute):
+
+    __slots__ = ('count', 'num_times_to_wait', 'switch')
+
+    def __init__(self, **kwargs):
+        if 'switch' in kwargs:
+            self.switch = kwargs['switch']
+            del kwargs['switch']
+        else:
+            self.switch = 0
+        self.count = 0
+        self.num_times_to_wait = 0
+        super(MockCompute, self).__init__(**kwargs)
+
+
+    def remote_submit_job(self, theurl, data, timeout):
+        with requests_mock.Mocker() as mock:
+            resp = {'job_id': '424242', 'qlength':2}
+            resp = json.dumps(resp)
+            if (self.switch % 2 == 0):
+                mock.register_uri('POST', '/dropq_start_job', status_code=502)
+                mock.register_uri('POST', '/elastic_gdp_start_job', status_code=502)
+            else:
+                mock.register_uri('POST', '/dropq_start_job', text=resp)
+                mock.register_uri('POST', '/elastic_gdp_start_job', text=resp)
+            self.switch += 1
+            return DropqCompute.remote_submit_job(self, theurl, data, timeout)

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -6,7 +6,8 @@ from ..models import TaxSaveInputs
 from ..models import convert_to_floats
 from ..helpers import (expand_1D, expand_2D, expand_list, package_up_vars,
                      format_csv, arrange_totals_by_row, default_taxcalc_data)
-from ..compute import DropqCompute, MockCompute, MockFailedCompute
+from ..compute import (DropqCompute, MockCompute, MockFailedCompute,
+                       NodeDownCompute)
 import taxcalc
 from taxcalc import Policy
 from .utils import *
@@ -72,6 +73,32 @@ class TaxBrainViewsTests(TestCase):
         # Check that we get a 400
         self.assertEqual(response.status_code, 400)
 
+    def test_taxbrain_nodes_down(self):
+        #Monkey patch to mock out running of compute jobs
+        import sys
+        from webapp.apps.taxbrain import views as webapp_views
+        webapp_views.dropq_compute = NodeDownCompute()
+
+        data = {u'ID_BenefitSurtax_Switch_1': [u'True'],
+                u'ID_BenefitSurtax_Switch_0': [u'True'],
+                u'ID_BenefitSurtax_Switch_3': [u'True'],
+                u'ID_BenefitSurtax_Switch_2': [u'True'],
+                u'ID_BenefitSurtax_Switch_5': [u'True'],
+                u'ID_BenefitSurtax_Switch_4': [u'True'],
+                u'ID_BenefitSurtax_Switch_6': [u'True'],
+                u'has_errors': [u'False'], u'II_em': [u'4333'],
+                u'start_year': unicode(START_YEAR), 'csrfmiddlewaretoken':'abc123'}
+
+        response = self.client.post('/taxbrain/', data)
+        # Check that redirect happens
+        self.assertEqual(response.status_code, 302)
+        link_idx = response.url[:-1].rfind('/')
+        self.failUnless(response.url[:link_idx+1].endswith("taxbrain/"))
+        # One more redirect
+        response = self.client.get(response.url)
+        # Check that we successfully load the page
+        response = self.client.get(response.url)
+        self.assertEqual(response.status_code, 200)
 
     def test_taxbrain_failed_job(self):
         #Monkey patch to mock out running of compute jobs


### PR DESCRIPTION
- Fixes a bug that would crash the app if attempting to submit to a node
  that is misbehaving. We only look at the contents of the repsonse if
  we get a 200 from the worker node