### PR TITLE
Fix multi-value params with multiple wildcards

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -331,7 +331,7 @@ def propagate_user_list(x, name, defaults, cpi, first_budget_year,
         if i < len(x):
             if is_wildcard(x[i]):
                 if multi_param_idx > -1:
-                    ans[i] = defaults[multi_param_idx][i]
+                    ans[i] = defaults[i][multi_param_idx]
                 else:
                     ans[i] = defaults[i]
 

--- a/webapp/apps/taxbrain/tests/test_all.py
+++ b/webapp/apps/taxbrain/tests/test_all.py
@@ -150,6 +150,14 @@ class TaxInputTests(TestCase):
                [250000, None, None, None, None, None]]
         assert ans['_AMED_thd'] == exp
 
+    def test_package_up_multivalue_param_with_wildcard3(self):
+        values = {"AMED_thd_0": [u'*', u'*', 250000]}
+        ans = package_up_vars(values, first_budget_year=FBY)
+        exp = [[200000, 250000.0, 125000.0, 200000.0, 200000.0, 125000.0],
+               [200000, None, None, None, None, None],
+               [250000, None, None, None, None, None]]
+        assert ans['_AMED_thd'] == exp
+
 
     def test_package_up_vars_unicode_wildcards(self):
         exp = [0.0089999999999999993, 0.0089999999999999993, 0.018]


### PR DESCRIPTION
- indexing was incorrect in plugging in expanded defaults
- add test for multiple wildcards in a multi-valued parameter