### PR TITLE
added widget page

### DIFF
--- a/templates/pages/embed.html
+++ b/templates/pages/embed.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="author" content="">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="/static/css/site.css" rel="stylesheet">
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="static 'static/js/vendor/html5shiv/html5shiv.min.js'"></script>
+      <script src="static 'js/vendor/respond/respond.min.js'"></script>
+    <![endif]-->
+  </head>
+<style>
+  #widget-iframe { 
+    height: {{ best_height }};
+    width: {{ best_width }};
+  }
+
+  #email-button {
+    background-color: #21bfd5 !important;
+    color: #ffffff !important;
+  }
+
+</style>
+
+
+  <div class="wrapper">
+    <div class="container">
+
+      <div class="page-header">
+        <h1 class="text-center">{{ widget_title }}</h1>
+      </div>
+
+      <iframe id="widget-iframe"
+	      src="{{ widget_url }}"
+	      scrolling="auto"
+       	      frameborder="0" ></iframe>
+
+        <div class="row">
+            <div class="col-md-1">
+		<img id="logoImg" src="//avatars0.githubusercontent.com/u/8301070?v=3&s=75"></img>
+	    </div>
+            <div class="col-md-11">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.</p>
+            </div>
+        </div>
+    </div> <!-- container -->
+
+    {% if include_email %}
+
+      <section class="join join-complete" id="join-mailinglist">
+        <h2>Join the community</h2>
+        <div class="input-container">
+          <div class="input-group">
+          <form action="{% url 'about' %}" method="post">{% csrf_token %}
+            <span class="input-group-btn">
+            {{ email_form.email }}
+            {{ email_form.email.errors }}
+            <input type="submit" class="btn btn-join" value="Sign Up"/>
+            </span>
+          </form>
+          </div>
+        </div>
+      </section>
+
+    {% endif %}
+
+</html>

--- a/templates/pages/widget.html
+++ b/templates/pages/widget.html
@@ -17,10 +17,6 @@
     color: #ffffff !important;
   }
 
-  #embed_code { 
-    background: hsl(220, 80%, 90%); 
-  }
-
   #embed_pre {
     white-space: pre-wrap;
     background: hsl(30,80%,90%);
@@ -57,11 +53,13 @@
         </div>
     </div> <!-- container -->
 
+    {% if include_email %}
+
       <section class="join join-complete" id="join-mailinglist">
         <h2>Join the community</h2>
         <div class="input-container">
           <div class="input-group">
-`          <form action="{% url 'about' %}" method="post">{% csrf_token %}
+          <form action="{% url 'about' %}" method="post">{% csrf_token %}
             <span class="input-group-btn">
             {{ email_form.email }}
             {{ email_form.email.errors }}
@@ -71,7 +69,7 @@
           </div>
         </div>
       </section>
-
+{% endif %}
 
 {% comment %}
     <!-- https://github.com/OpenSourcePolicyCenter/webapp-public/issues/56 -->
@@ -109,7 +107,7 @@
         </div>
       </section>
       <section class="contact-info">
-	      {{% flatblock "reach_out_community_link" %}
+	      {% flatblock "reach_out_community_link" %}
         <ul class="contact-social">
           <li class="contact-twitter"><a href="#">Post link on Twitter</a></li>
           <li class="contact-facebook"><a href="#">Share on Facebook</a></li>

--- a/templates/pages/widget.html
+++ b/templates/pages/widget.html
@@ -7,10 +7,25 @@
 {% block content %}
 
 <style>
-  iframe { 
-	  height: 600px;
-	  width: 100%;
+  #widget-iframe { 
+    height: {{ best_height }};
+    width: {{ best_width }};
   }
+
+  #email-button {
+    background-color: #21bfd5 !important;
+    color: #ffffff !important;
+  }
+
+  #embed_code { 
+    background: hsl(220, 80%, 90%); 
+  }
+
+  #embed_pre {
+    white-space: pre-wrap;
+    background: hsl(30,80%,90%);
+  }
+
 </style>
 
 
@@ -21,9 +36,42 @@
         <h1 class="text-center">{{ widget_title }}</h1>
       </div>
 
-      <iframe src="{{ widget_url }}" scrolling="auto" frameborder="0"></iframe>
+      <iframe id="widget-iframe"
+	      src="{{ widget_url }}"
+	      scrolling="auto"
+       	      frameborder="0" ></iframe>
 
+        <div class="row">
+            <div class="col-md-1">
+		<img id="logoImg" src="//avatars0.githubusercontent.com/u/8301070?v=3&s=75"></img>
+	    </div>
+            <div class="col-md-11">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam viverra euismod odio, gravida pellentesque urna varius vitae.</p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+		    <h3>Embed this plot:</h3>
+		    <pre id="embed_pre"><code id="embed_code">&lt;iframe id="widget-iframe" src="{{ embed_url }}" style="height:{{ best_height }};width:{{ best_width}};" scrolling="auto" frameborder="0" &gt;&lt;/iframe&gt;</code></pre>
+	    </div>
+        </div>
     </div> <!-- container -->
+
+      <section class="join join-complete" id="join-mailinglist">
+        <h2>Join the community</h2>
+        <div class="input-container">
+          <div class="input-group">
+`          <form action="{% url 'about' %}" method="post">{% csrf_token %}
+            <span class="input-group-btn">
+            {{ email_form.email }}
+            {{ email_form.email.errors }}
+            <input type="submit" class="btn btn-join" value="Sign Up"/>
+            </span>
+          </form>
+          </div>
+        </div>
+      </section>
+
 
 {% comment %}
     <!-- https://github.com/OpenSourcePolicyCenter/webapp-public/issues/56 -->
@@ -61,7 +109,7 @@
         </div>
       </section>
       <section class="contact-info">
-        {% flatblock "reach_out_community_link" %}
+	      {{% flatblock "reach_out_community_link" %}
         <ul class="contact-social">
           <li class="contact-twitter"><a href="#">Post link on Twitter</a></li>
           <li class="contact-facebook"><a href="#">Share on Facebook</a></li>
@@ -87,8 +135,6 @@
         </div>
       </section>
     </div>
-     
-
     <div class="push"></div>
   </div> <!-- /wrapper -->
 {% endblock %}

--- a/templates/pages/widget.html
+++ b/templates/pages/widget.html
@@ -1,0 +1,94 @@
+{% extends 'pages/home.html' %}
+
+{% load staticfiles %}
+
+{% load flatblocks %}
+
+{% block content %}
+
+<style>
+  iframe { 
+	  height: 600px;
+	  width: 100%;
+  }
+</style>
+
+
+  <div class="wrapper">
+    <div class="container">
+
+      <div class="page-header">
+        <h1 class="text-center">{{ widget_title }}</h1>
+      </div>
+
+      <iframe src="{{ widget_url }}" scrolling="auto" frameborder="0"></iframe>
+
+    </div> <!-- container -->
+
+{% comment %}
+    <!-- https://github.com/OpenSourcePolicyCenter/webapp-public/issues/56 -->
+    <div class="section-header">
+      <h2>What People Are Saying</h2>
+    </div>
+    
+    <section class="news-items">
+      <div class="container">
+        <p class="text-right"><a href="#" class="see-all">See all news</a></p>
+        <div class="row">
+          <div class="col-sm-6">
+            <div class="news-item tagged">
+              <h4><a href="#">Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</a></h4>
+              <p>Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.</p>
+            </div>
+          </div>
+          <div class="col-sm-6">
+            <div class="news-item tagged">
+              <h4><a href="#">Sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</a></h4>
+              <p>Vestibulum id ligula porta felis euismod semper. Curabitur blandit tempus porttitor.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+{% endcomment %}
+
+    <div class="container">
+      <section class="sponsor-info">
+        <h2>Our Sponsor</h2>
+        <div>
+          <img src="{% static 'images/logo-aei.png' %}" alt="AEI" class="img-responsive">
+        </div>
+      </section>
+      <section class="contact-info">
+        {% flatblock "reach_out_community_link" %}
+        <ul class="contact-social">
+          <li class="contact-twitter"><a href="#">Post link on Twitter</a></li>
+          <li class="contact-facebook"><a href="#">Share on Facebook</a></li>
+          <li class="contact-linkedin"><a href="#">Discuss on LinkedIn</a></li>
+        </ul>
+        <div class="contact-info-break"></div>
+        <div class="row">
+          <div class="col-sm-5 col-sm-offset-5">
+            <h3>MATT JENSEN</h3>
+            <p>+1 202 862 5941</p>
+            <p>matt.jensen@aei.org</p>
+          </div>
+          <!--
+          <div class="col-sm-5">
+            <h3>PERSON NAME, PH.D.</h3>
+            <p>+1 555 555-3333 voice<br>
+            hello@mediacontactinfo.us</p>
+            <p>Company name PR<br>
+            1000 N Streetname Ave Suite 34<br>
+            Washington, DC 10000</p>
+          </div>
+          -->
+        </div>
+      </section>
+    </div>
+     
+
+    <div class="push"></div>
+  </div> <!-- /wrapper -->
+{% endblock %}

--- a/webapp/apps/pages/urls.py
+++ b/webapp/apps/pages/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import patterns, include, url
 
-from views import homepage, aboutpage, newspage, newsdetailpage, widgetpage
+from views import homepage, aboutpage, newspage
+from views import embedpage, widgetpage,newsdetailpage
 
 urlpatterns = patterns('',
     url(r'^$', homepage, name='home'),
@@ -8,4 +9,5 @@ urlpatterns = patterns('',
     url(r'^news/$', newspage, name='news'),
     url(r'^news/news-detail$', newsdetailpage, name='newsdetail'),
     url(r'^widgets/(?P<widget_id>\w+)/$', widgetpage),
+    url(r'^widgets/embed/(?P<widget_id>\w+)/$', embedpage),
 )

--- a/webapp/apps/pages/urls.py
+++ b/webapp/apps/pages/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import patterns, include, url
 
-from views import homepage, aboutpage, newspage, newsdetailpage
-
+from views import homepage, aboutpage, newspage, newsdetailpage, widgetpage
 
 urlpatterns = patterns('',
     url(r'^$', homepage, name='home'),
     url(r'^about/$', aboutpage, name='about'),
     url(r'^news/$', newspage, name='news'),
     url(r'^news/news-detail$', newsdetailpage, name='newsdetail'),
+    url(r'^widgets/(?P<widget_id>\w+)/$', widgetpage),
 )

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -61,3 +61,39 @@ def newspage(request):
 
 def newsdetailpage(request):
     return redirect(BLOG_URL)
+
+def _discover_widgets():
+    '''stubbed out data I wish to recieve from some widget discovery mechanism'''
+    tre_widget = dict()
+    tre_widget['title'] = 'Tax Reform Explorer'
+    tre_widget['src'] = 'http://bcollins-outbox.s3.amazonaws.com/tax-reform-explorer.html'
+    tre_widget['include_email'] = True
+
+    widgets = dict()
+    widgets['taxreformexplorer'] = tre_widget
+
+    return widgets
+
+def widgetpage(request, widget_id):
+
+    widgets = _discover_widgets()
+
+    if widget_id not in widgets.keys():
+        raise ValueError('Invalid Widget Id {0}'.format(widget_id))
+
+    widget = widgets[widget_id]
+
+    form = subscribeform(request)
+    if request.method == 'POST' and form.is_valid():
+        return check_email(request)
+
+    test_1 = render(request, 'pages/widget.html', {
+        'csrv_token': csrf(request)['csrf_token'],
+        'email_form': form,
+        'widget_title': widget['title'],
+        'widget_url': widget['src'],
+        'section': {
+            'title': 'Widget',
+        }
+    })
+    return test_1

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -90,18 +90,43 @@ def widgetpage(request, widget_id):
 
     widget = widgets[widget_id]
 
-    #form = subscribeform(request)
-    #if request.method == 'POST' and form.is_valid():
-        #return check_email(request)
+    form = subscribeform(request)
+    if request.method == 'POST' and form.is_valid():
+        return check_email(request)
 
-    form = None
+    request.get_host()
+    embed_url = os.path.join('//',request.get_host(), 'widgets', 'embed', widget_id)
 
     return render(request, 'pages/widget.html', {
         'csrv_token': csrf(request)['csrf_token'],
         'email_form': form,
+        'embed_url': embed_url,
+        'best_width': widget.get('best_width'),
+        'best_height': widget.get('best_height'),
         'widget_title': widget['plot_name'],
         'widget_url': widget['plot_url'],
         'section': {
             'title': 'Widget',
         }
+    })
+
+def embedpage(request, widget_id):
+    form = subscribeform(request)
+
+    widgets = _discover_widgets()
+
+    if widget_id not in widgets.keys():
+        raise ValueError('Invalid Widget Id {0}'.format(widget_id))
+
+    widget = widgets[widget_id]
+
+    form = subscribeform(request)
+    if request.method == 'POST' and form.is_valid():
+        return check_email(request)
+
+    return render(request, 'pages/embed.html', {
+        'best_width': widget.get('best_width'),
+        'best_height': widget.get('best_height'),
+        'widget_title': widget['plot_name'],
+        'widget_url': widget['plot_url'],
     })

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -95,7 +95,7 @@ def widgetpage(request, widget_id):
         return check_email(request)
 
     request.get_host()
-    embed_url = os.path.join('//',request.get_host(), 'widgets', 'embed', widget_id)
+    embed_url = os.path.join('http://',request.get_host(), 'widgets', 'embed', widget_id)
 
     return render(request, 'pages/widget.html', {
         'csrv_token': csrf(request)['csrf_token'],

--- a/webapp/apps/pages/views.py
+++ b/webapp/apps/pages/views.py
@@ -97,10 +97,16 @@ def widgetpage(request, widget_id):
     request.get_host()
     embed_url = os.path.join('http://',request.get_host(), 'widgets', 'embed', widget_id)
 
+    if request.method == 'GET':
+        include_email = request.GET.get('includeEmail', '') == '1'
+    else:
+        include_email = False
+
     return render(request, 'pages/widget.html', {
         'csrv_token': csrf(request)['csrf_token'],
         'email_form': form,
         'embed_url': embed_url,
+        'include_email': include_email,
         'best_width': widget.get('best_width'),
         'best_height': widget.get('best_height'),
         'widget_title': widget['plot_name'],
@@ -124,9 +130,16 @@ def embedpage(request, widget_id):
     if request.method == 'POST' and form.is_valid():
         return check_email(request)
 
+    if request.method == 'GET':
+        include_email = request.GET.get('includeEmail', '') == '1'
+    else:
+        include_email = False
+
     return render(request, 'pages/embed.html', {
         'best_width': widget.get('best_width'),
         'best_height': widget.get('best_height'),
         'widget_title': widget['plot_name'],
         'widget_url': widget['plot_url'],
+        'email_form': form,
+        'include_email': include_email,
     })


### PR DESCRIPTION
This PR adds an additional endpoint for accessing widgets (e.g. `tax reform explorer`).

An individual widget is accessed by id using the following url syntax:
`/widgets/<widget_id>/`

- [x] add basic view/template/urls for accessing an embedded widget
- [ ] integrate flag for show/hide of email field
- [ ] add database field for storing user email address if submitted
- [ ] parameterize logo (if needed)
- [x] create a mechanism to discover new widgets.  At the moment, there is a function called `_discover_widgets` which returns a rough idea of what I'd expect.
- [ ] test what happens when bunk widget id is submitted. 
- [ ] test embedding widget on 3rd party page.
- [ ] add some `format` url param to specify whether to return iframe, or simply json with relevant widget details
- [ ] integrate with additional `gallery` tab (after `apps` and before `about`) and page

