### PR TITLE
Fix incorrect assert in propagate_user_list

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -329,7 +329,7 @@ def propagate_user_list(x, name, defaults, cpi, first_budget_year,
     """
     # x must have a real first value
     assert len(x) > 0
-    assert x[0]
+    assert x[0] not in ("", None)
 
     num_years = max(len(defaults), len(x))
 

--- a/webapp/apps/taxbrain/tests/test_all.py
+++ b/webapp/apps/taxbrain/tests/test_all.py
@@ -333,6 +333,16 @@ class TaxInputTests(TestCase):
                                      [0.09, 0.17578, 0.23166, 0.23166]]}
 
 
+    def test_package_up_eitc_with_zeros(self):
+        values = {'EITC_rt_0': [0.0]}
+        ans = package_up_vars(values, first_budget_year=FBY)
+        assert ans == {'_EITC_rt': [[0.0, 0.34, 0.4, 0.45]]}
+
+    def test_package_up_id_charity_frt_with_zeros(self):
+        values = {'ID_Charity_frt': [u'*', u'*', 0.0]}
+        ans = package_up_vars(values, first_budget_year=FBY)
+        assert ans == {'_ID_Charity_frt': [0.0, 0.0, 0.0]}
+
     def test_package_up_vars_Behavioral_params(self):
         user_values = {'FICA_ss_trt': [0.11],
                        'BE_inc': [0.04]}


### PR DESCRIPTION
- floating point 0 asserts to False. Correct assertion here is making
  sure that the empty string or None is not passed

Resolves #259 and #261 