### PR TITLE
Fix: wildcard entries propagate to part. eq. sims

### DIFF
--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -34,7 +34,8 @@ from .models import (DynamicSaveInputs, DynamicOutputUrl,
                      DynamicElasticitySaveInputs, DynamicElasticityOutputUrl)
 from ..taxbrain.models import TaxSaveInputs, OutputUrl
 from ..taxbrain.views import growth_fixup, benefit_surtax_fixup, make_bool
-from ..taxbrain.helpers import default_policy, taxcalc_results_to_tables, default_behavior
+from ..taxbrain.helpers import (default_policy, taxcalc_results_to_tables, default_behavior,
+                                convert_val)
 from ..taxbrain.views import dropq_compute
 
 from .helpers import (default_parameters, job_submitted,
@@ -188,10 +189,7 @@ def dynamic_behavioral(request, pk):
 
             for key, value in curr_dict.items():
                 if type(value) == type(unicode()):
-                    try:
-                        curr_dict[key] = [float(x) for x in value.split(',') if x]
-                    except ValueError:
-                        curr_dict[key] = [make_bool(x) for x in value.split(',') if x]
+                    curr_dict[key] = [convert_val(x) for x in value.split(',') if x]
                 else:
                     print "missing this: ", key
 
@@ -206,10 +204,7 @@ def dynamic_behavioral(request, pk):
             growth_fixup(taxbrain_dict)
             for key, value in taxbrain_dict.items():
                 if type(value) == type(unicode()):
-                    try:
-                        taxbrain_dict[key] = [float(x) for x in value.split(',') if x]
-                    except ValueError:
-                        taxbrain_dict[key] = [make_bool(x) for x in value.split(',') if x]
+                    taxbrain_dict[key] = [convert_val(x) for x in value.split(',') if x]
                 else:
                     print "missing this: ", key
 
@@ -310,10 +305,7 @@ def dynamic_elasticities(request, pk):
             growth_fixup(taxbrain_dict)
             for key, value in taxbrain_dict.items():
                 if type(value) == type(unicode()):
-                    try:
-                        taxbrain_dict[key] = [float(x) for x in value.split(',') if x]
-                    except ValueError:
-                        taxbrain_dict[key] = [make_bool(x) for x in value.split(',') if x]
+                        taxbrain_dict[key] = [convert_val(x) for x in value.split(',') if x]
                 else:
                     print "missing this: ", key
 

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -227,7 +227,7 @@ class DropqCompute(object):
 
 class MockCompute(DropqCompute):
 
-    __slots__ = ('count', 'num_times_to_wait')
+    __slots__ = ('count', 'num_times_to_wait', 'last_posted')
 
     def __init__(self, num_times_to_wait=0):
         self.count = 0
@@ -241,6 +241,7 @@ class MockCompute(DropqCompute):
             resp = json.dumps(resp)
             mock.register_uri('POST', '/dropq_start_job', text=resp)
             mock.register_uri('POST', '/elastic_gdp_start_job', text=resp)
+            self.last_posted = data
             return DropqCompute.remote_submit_job(self, theurl, data, timeout)
 
     def remote_results_ready(self, theurl, params):


### PR DESCRIPTION
- Resolves #206
- Partial equilibrium simulations based on microsim runs that involved
  wildcard entries for reform parameters were not getting the proper
  reform parameters. Now they are correctly processed and sent off for
  processing