### PR TITLE
Add flag to increment worker nodes counter

### DIFF
--- a/webapp/apps/btax/compute.py
+++ b/webapp/apps/btax/compute.py
@@ -42,7 +42,9 @@ class DropqComputeBtax(DropqCompute):
         url_template = "http://{hn}/btax_start_job"
         return self.submit_calculation(mods, first_budget_year, url_template,
                                        start_budget_year=None, num_years=1,
-                                       workers=BTAX_WORKERS)
+                                       workers=BTAX_WORKERS,
+                                       increment_counter=False,
+                                       use_wnc_offset=False)
 
 
 class MockComputeBtax(MockCompute, DropqComputeBtax):


### PR DESCRIPTION
 - For BTax workloads, we don't need to increment the counter
   that keeps track of of offset in the worker node pool

 - depends on #319 