### PR TITLE
Better formating for file-based reuslts pages

### DIFF
--- a/templates/taxbrain/includes/params/inputs/file.html
+++ b/templates/taxbrain/includes/params/inputs/file.html
@@ -7,13 +7,11 @@
 
 {% block content %}
 <div class="inputs-block-header">
-  <h1>JSON Input Parameters</h1>
+    <h1>Reform File: See examples <a href="https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/reforms/REFORMS.md">here</a></h1>
   {% flatblock "taxbrain_json_blurb" %}
   {% block section_warnings %}
   {% endblock %}
 </div>
-
-<h2>Tax Calculator Parameters</h2>
 
 <p><label for="id_docfile">Select a file:</label> </p>
 

--- a/templates/taxbrain/input_file.html
+++ b/templates/taxbrain/input_file.html
@@ -94,9 +94,6 @@
                   {% flatblock "taxbrain_above_get_started_blurb" %}
                   <h1 id="get-started">Get Started</h1>
                   {% flatblock "taxbrain_get_started_json_blurb" %}
-                  <div>
-                    You are looking at default parameters for {{start_year}}.
-                  </div>
                 </div>
               </div>
 

--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -25,6 +25,15 @@
       margin-bottom: 40px;
       text-align: left;
   }
+  .file-contents{
+      font-family: "Courier New", Courier, monospace;
+      font-weight: bold;
+      margin-left: 80px;
+      margin-right: 80px;
+      margin-top: 40px;
+      margin-bottom: 40px;
+      text-align: left;
+  }
 </style>
 {% endblock %}
 {% block content %}
@@ -55,9 +64,11 @@
         {% endif %}
       </div>
       {% if file_contents %}
-      <h2> The following parameters were uploaded for this simulation: </h2>
-      <div class="param-text">
-        {{file_contents | linebreaks }}
+      <h2> The following reform file was uploaded for this simulation: </h2>
+      <div class="file-contents">
+          {%autoescape off %}
+          {{file_contents | linebreaks | safe }}
+          {%endautoescape %}
        </div>
       {% endif %}
     </div>

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -589,6 +589,7 @@ def get_result_context(model, request, url):
     else:
         file_contents = False
 
+    file_contents = file_contents.replace(" ","&nbsp;")
     is_registered = True if request.user.is_authenticated() else False
     context = {
         'locals':locals(),

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -586,10 +586,10 @@ def get_result_context(model, request, url):
 
     if model.json_text:
         file_contents = model.json_text.text
+        file_contents = file_contents.replace(" ","&nbsp;")
     else:
         file_contents = False
 
-    file_contents = file_contents.replace(" ","&nbsp;")
     is_registered = True if request.user.is_authenticated() else False
     context = {
         'locals':locals(),


### PR DESCRIPTION
 - monospace font for reform file text
 - white space respected in text from file
 - More descriptive/appropriate text on file-based reform input page