### PR TITLE
Improved error reporting on file-based runs

### DIFF
--- a/templates/taxbrain/failed.html
+++ b/templates/taxbrain/failed.html
@@ -1,6 +1,20 @@
 {% extends 'taxbrain/input_base.html' %}
 
 {% load staticfiles %}
+{% block style %}
+{{block.super}}
+<style>
+  .file-contents{
+      font-family: "Courier New", Courier, monospace;
+      font-weight: bold;
+      margin-left: 80px;
+      margin-right: 80px;
+      margin-top: 40px;
+      margin-bottom: 40px;
+      text-align: left;
+  }
+</style>
+{% endblock %}
 
 {% block content %}
 {% include 'taxbrain/header.html' %}
@@ -11,7 +25,12 @@
             <h1>Sorry! Your calculation failed. Please re-enter parameters and try again :(.</h1>
         </div>
     </div>
-    {{ error_msg | linebreaks }}
+
+    <div class="file-contents">
+          {%autoescape off %}
+          {{error_msg | linebreaks | safe }}
+          {%endautoescape %}
+    </div>
 </div>
 
 {% endblock %}

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -649,11 +649,12 @@ def output_detail(request, pk):
             error_msg = error_msgs[0]
             val_err_idx = error_msg.rfind("Error")
             error = ErrorMessageTaxCalculator()
-            error.text = error_msg[val_err_idx:]
+            error_contents = error_msg[val_err_idx:].replace(" ","&nbsp;")
+            error.text = error_contents
             error.save()
             model.error_text = error
             model.save()
-            return render(request, 'taxbrain/failed.html', {"error_msg": error_msg[val_err_idx:]})
+            return render(request, 'taxbrain/failed.html', {"error_msg": error_contents})
 
 
         if all([j == 'YES' for j in jobs_ready]):


### PR DESCRIPTION
 - Errors from file-based TaxBrain runs are reported in monospace font
   and with white space respected.

 - resolves #370