### PR TITLE
update tooltip references

### DIFF
--- a/webapp/apps/btax/helpers.py
+++ b/webapp/apps/btax/helpers.py
@@ -159,9 +159,9 @@ def hover_args_to_btax_depr():
     hover_notes = {}
     defaults = dict(DEFAULTS)
     hover_notes['gds_note'] = defaults['btax_depr_hover_gds_Switch']['notes']
-    hover_notes['ads_note'] = defaults['btax_depr_hover_exp']['notes']
-    hover_notes['economic_note'] = defaults['btax_depr_hover_ads_Switch']['notes']
-    hover_notes['bonus_note'] = defaults['btax_depr_hover_tax_Switch']['notes']
+    hover_notes['ads_note'] = defaults['btax_depr_hover_ads_Switch']['notes']
+    hover_notes['economic_note'] = defaults['btax_depr_hover_tax_Switch']['notes']
+    hover_notes['bonus_note'] = defaults['btax_depr_hover_exp']['notes']
     return hover_notes
 
 


### PR DESCRIPTION
This PR updates the references used to pull text from the `btax_defaults.json` file for the hover tooltips in the CCC depreciation parameters input table.