### PR TITLE
Fix /ccc row ordering issues: 385, 386, 387, 388

### DIFF
--- a/templates/btax/results.html
+++ b/templates/btax/results.html
@@ -266,21 +266,14 @@
                         </tr>
                      `);
                      continue;
-                  }else{
-                    $table_body.append(`
-                      <tr class="group">
-                        <td colspan="7">
-                            <strong>${row.major_grouping}</strong> &emsp;
-                            Non-Corporate: ${row.summary_nc} &emsp;
-                            Corporate: ${row.summary_c}
-                        </td>
-                      </tr>
-                    `);
-                    }
+                  }
+                  var label_cls = "group";
+               }else{
+                  var label_cls = "data-label";
                }
                $table_body.append(`
                     <tr>
-                     <td class="data-label">${sb}${row.label}${se}</td>
+                     <td class="${label_cls}">${sb}${row.label}${se}</td>
                         <td>${sb}${formatValue(row.cells, 0)}${se}</td>
                         <td>${sb}${formatValue(row.cells, 1)}${se}</td>
                         <td>${sb}${formatValue(row.cells, 2)}${se}</td>

--- a/templates/btax/results.html
+++ b/templates/btax/results.html
@@ -43,7 +43,7 @@
 
   .tooltip-inner {
     min-width: 200px;
-    max-width: 100%; 
+    max-width: 100%;
   }
 
   #results-container {
@@ -58,8 +58,8 @@
     padding-left:20px !important;
   }
 
-  table.dataTable thead .sorting, 
-  table.dataTable thead .sorting_asc, 
+  table.dataTable thead .sorting,
+  table.dataTable thead .sorting_asc,
   table.dataTable thead .sorting_desc {
      background : none;
      cursor: default;
@@ -240,19 +240,6 @@
 			</thead>
               `);
 
-           $table.append(`
-			<tfoot>
-				  <tr>
-					<th>Industry</th>
-					<th>Corporate</th>
-					<th>Non-corporate</th>
-					<th>Corporate</th>
-					<th>Non-corporate</th>
-					<th>Corporate</th>
-					<th>Non-corporate</th>
-				  </tr>
-			</tfoot>
-              `);
 
            var $table_body = $('<tbody/>');
 
@@ -262,57 +249,51 @@
 
            for(var i=0; i < items.rows.length - 1; i++) {
                row = items.rows[i];
-			   $table_body.append(`
-				  <tr>
-					<td class="data-label">${row.label}</td>
-					<td>${formatValue(row.cells, 0)}</td>
-					<td>${formatValue(row.cells, 1)}</td>
-					<td>${formatValue(row.cells, 2)}</td>
-					<td>${formatValue(row.cells, 3)}</td>
-					<td>${formatValue(row.cells, 4)}</td>
-					<td>${formatValue(row.cells, 5)}</td>
-					<td>${row.major_grouping}</td>
-					<td>${row.summary_nc}</td>
-					<td>${row.summary_c}</td>
-				  </tr>
-				  `);
-           }
+               if(row.label == row.major_grouping){
+                  var sb = "<strong>";
+                  var se = "</strong>";
+               }else{
+                  var sb = "";
+                  var se = "";
+               }
+               if(row.major_grouping === row.label){
+                  if(row.summary_c === 'breakline'){
+                     $table_body.append(`
+                        <tr>
+                            <td class="data-label" colspan="7">
+                                <strong>${row.label}</strong>
+                            </td>
+                        </tr>
+                     `);
+                     continue;
+                  }else{
+                    $table_body.append(`
+                      <tr class="group">
+                        <td colspan="7">
+                            <strong>${row.major_grouping}</strong> &emsp;
+                            Non-Corporate: ${row.summary_nc} &emsp;
+                            Corporate: ${row.summary_c}
+                        </td>
+                      </tr>
+                    `);
+                    }
+               }
+               $table_body.append(`
+                    <tr>
+                     <td class="data-label">${sb}${row.label}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 0)}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 1)}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 2)}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 3)}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 4)}${se}</td>
+                        <td>${sb}${formatValue(row.cells, 5)}${se}</td>
+                    </tr>`);
+            }
 
            $table.append($table_body);
            $('#results-table-area').html($table);
 	   };
-	
-	var onTableDraw =  function(settings) {
-	    var cur_page = { page:'current' };
-	    var api = this.api();
-	    var rows = api.rows(cur_page).nodes();
- 
-	    var major_groupings = api.column(7, cur_page).data();
-	    var summary_ncs = api.column(8, cur_page).data();
-	    var summary_cs = api.column(9, cur_page).data();
 
-	    var summary_nc = null;
-	    var summary_c = null;
-
-	    var last = null;
-	    major_groupings.each(function(group, i) {
-	        summary_nc = summary_ncs[i];
-	        summary_c = summary_cs[i];
-		if (last !== group) {
-		    $(rows).eq(i).before(`
-			  <tr class="group">
-				<td colspan="7">
-				    <strong>${group}</strong> &emsp;
-				    Non-Corporate: ${summary_nc} &emsp;
-				    Corporate: ${summary_c}
-				</td>
-			  </tr>
-		    `);
-
-		    last = group;
-		}
-	    });
-	};
 
        var buildTable = function() {
 
@@ -327,7 +308,6 @@
 		"order": [[7, 'asc']],
 		"paging":false,
 		"info":false,
-		"drawCallback":onTableDraw
 	    });
        };
 
@@ -341,7 +321,7 @@
     buildTable();
 
 
- 
+
     // Order by the grouping
     $('table tbody').on( 'click', 'tr.group', function () {
         var currentOrder = table.order()[0];

--- a/webapp/apps/btax/helpers.py
+++ b/webapp/apps/btax/helpers.py
@@ -42,6 +42,11 @@ BTAX_ECON = ['btax_econ_nomint', 'btax_econ_inflat',]
 BTAX_VERSION_INFO = btax._version.get_versions()
 BTAX_VERSION = ".".join([BTAX_VERSION_INFO['version'], BTAX_VERSION_INFO['full-revisionid'][:6]])
 
+# Row labels, in order, including minor headings like "Durable goods"
+BTAX_TABLE_ASSET_ORDER = ("Equipment", "Mainframes", "PCs", "DASDs", "Printers", "Terminals", "Tape drives", "Storage devices", "System integrators", "Communications", "Nonelectro medical instruments", "Electro medical instruments", "Nonmedical instruments", "Photocopy and related equipment", "Office and accounting equipment", "Nuclear fuel", "Other fabricated metals", "Steam engines", "Internal combustion engines", "Metalworking machinery", "Special industrial machinery", "General industrial equipment", "Electric transmission and distribution", "Light trucks (including utility vehicles)", "Other trucks, buses and truck trailers", "Autos", "Aircraft", "Ships and boats", "Railroad equipment", "Household furniture", "Other furniture", "Other agricultural machinery", "Farm tractors", "Other construction machinery", "Construction tractors", "Mining and oilfield machinery", "Service industry machinery", "Household appliances", "Other electrical", "Other", "Structures", "Office", "Hospitals", "Special care", "Medical buildings", "Multimerchandise shopping", "Food and beverage establishments", "Warehouses", "Mobile structures", "Other commercial", "Manufacturing", "Electric", "Wind and solar", "Gas", "Petroleum pipelines", "Communication", "Petroleum and natural gas", "Mining", "Educational and vocational", "Lodging", "Amusement and recreation", "Air transportation", "Other transportation", "Other railroad", "Track replacement", "Local transit structures", "Other land transportation", "Farm", "Water supply", "Sewage and waste disposal", "Public safety", "Highway and conservation and development", "Inventories", "Land")
+BTAX_TABLE_INDUSTRY_ORDER = ("Agriculture, forestry, fishing, and hunting", "Farms", "Forestry, fishing, and related activities", "Mining", "Oil and gas extraction", "Mining, except oil and gas", "Support activities for mining", "Utilities", "Construction", "Manufacturing", "Durable goods", "Wood products", "Nonmetallic mineral products", "Primary metals", "Fabricated metal products", "Machinery", "Computer and electronic products", "Electrical equipment, appliances, and components", "Motor vehicles, bodies and trailers, and parts", "Other transportation equipment", "Furniture and related products", "Miscellaneous manufacturing", "Nondurable goods", "Food, beverage, and tobacco products", "Textile mills and textile product mills", "Apparel and leather and allied products", "Paper products", "Printing and related support activities", "Petroleum and coal products", "Chemical products", "Plastics and rubber products", "Wholesale trade", "Retail trade", "Transportation and warehousing", "Air transportation", "Railroad transportation", "Water transportation", "Truck transportation", "Transit and ground passenger transportation", "Pipeline transportation", "Other transportation and support activities", "Warehousing and storage", "Information", "Publishing industries (including software)", "Motion picture and sound recording industries", "Broadcasting and telecommunications", "Information and data processing services", "Finance and insurance", "Credit intermediation and related activities", "Securities, commodity contracts, and investments", "Insurance carriers and related activities", "Funds, trusts, and other financial vehicles", "Real estate and rental and leasing", "Real estate", "Rental and leasing services and lessors of intangible assets", "Professional, scientific, and technical services", "Legal services", "Computer systems design and related services", "Miscellaneous professional, scientific, and technical services", "Management of companies and enterprises", "Administrative and waste management services", "Administrative and support services", "Waste management and remediation services", "Educational services", "Health care and social assistance", "Ambulatory health care services", "Hospitals", "Nursing and residential care facilities", "Social assistance", "Arts, entertainment, and recreation", "Performing arts, spectator sports, museums, and related activities", "Amusements, gambling, and recreation industries", "Accommodation and food services", "Accommodation", "Food services and drinking places", "Other services, except government")
+# If any minor headings are needed, such as "Durable goods", put them in "breaks" below
+BTAX_TABLE_BREAKS = {'industry': ['Durable goods', 'Nondurable goods'], 'asset': []}
 #
 # Prepare user params to send to DropQ/Taxcalc
 #
@@ -249,9 +254,39 @@ def btax_results_to_tables(results, first_budget_year):
 
             col_count = len(col_labels)
             group_data = row_grouping['asset' if is_asset else 'industry']
-
-            for idx, row_label in enumerate(row_labels, 1):
-                group = group_data[row_label]
+            spaces = (u'\xa0', u'\u00a0', u' ')
+            keys = tuple(group_data)
+            ks = [[char for char in _ if char not in spaces]
+                   for _ in group_data]
+            if is_asset:
+                row_order = BTAX_TABLE_ASSET_ORDER
+            else:
+                row_order = BTAX_TABLE_INDUSTRY_ORDER
+            breaks = BTAX_TABLE_BREAKS['asset' if is_asset else 'industry']
+            def closest_spell(a):
+                '''Ignore spaces, including unicode-encoded spaces
+                   for comparison'''
+                k = [k for k in ks
+                     if a and [char for char in a if char not in spaces] == k][0]
+                return keys[ks.index(k)]
+            befores = []
+            for b in breaks:
+                before = [r1 for r1, r2 in zip(row_order[:-1], row_order[1:])
+                          if r2 == b][0]
+                befores.append(before)
+            row_order = [r for r in row_order if r not in breaks]
+            for idx, row_label in enumerate(row_order, 1):
+                if row_label in befores:
+                    lab = breaks[befores.index(row_label)]
+                    extra_row = {'label': lab,
+                                 'summary_c': 'breakline',
+                                 'summary_nc': 'breakline',
+                                 'major_grouping': lab,
+                                 'cells': []}
+                else:
+                    extra_row = None
+                row_key = closest_spell(row_label)
+                group = group_data[row_key]
                 row = {
                     'label': row_label,
                     'cells': [],
@@ -272,8 +307,9 @@ def btax_results_to_tables(results, first_budget_year):
 
                     cell['value'] = value
                     row['cells'].append(cell)
-
                 table['rows'].append(row)
+                if extra_row:
+                    table['rows'].append(extra_row)
 
             tables[upper_key][table_id] = table
     tables['result_years'] = [2015]


### PR DESCRIPTION
This fixes issues related to row ordering on /ccc results tables and gets rid of the extra footer info.

Here is the new industry look:
<img width="1067" alt="screen shot 2016-10-28 at 12 16 01 pm" src="https://cloud.githubusercontent.com/assets/1445602/19819192/66c9f40c-9d08-11e6-9a41-69c3ada5c235.png">

This shows the minor headings "Durable goods" and "Nondurable goods" inside "Manufacturing" section:
<img width="1035" alt="screen shot 2016-10-28 at 12 16 17 pm" src="https://cloud.githubusercontent.com/assets/1445602/19819210/7adfacfc-9d08-11e6-8940-7d566b1eb42d.png">


And here's the fixed footer:
<img width="1055" alt="screen shot 2016-10-28 at 12 16 24 pm" src="https://cloud.githubusercontent.com/assets/1445602/19819219/841725c0-9d08-11e6-8073-60f1ffba5669.png">
