### PR TITLE
add All Investments row at the bottom of /ccc results tables

### DIFF
--- a/templates/btax/results.html
+++ b/templates/btax/results.html
@@ -248,7 +248,7 @@
            var row;
            var items = window.tableData[window.viewBy + '_' + window.outputInterest][window.outputFormat];
 
-           for(var i=0; i < items.rows.length - 1; i++) {
+           for(var i=0; i < items.rows.length; i++) {
                row = items.rows[i];
                if(row.label == row.major_grouping){
                   var sb = "<strong>";


### PR DESCRIPTION
Ensure the "All Investments" row is at the bottom of each of /ccc results tables.  Must work with [B-Tax PR 120](https://github.com/open-source-economics/B-Tax/pull/120)