### PR TITLE
Only allow links to dynamic simulations on non-behavior run

### DIFF
--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -60,7 +60,7 @@
         <a href="/dynamic/behavioral/edit/{{ unique_url.pk }}/?start_year={{ first_year }}" class="text-white btn btn-secondary">Edit Parameters</a>
         {% endif %}
         {% if is_micro %}
-        <a href="/dynamic/{{ unique_url.pk }}/?start_year={{ first_year }}" class="text-white btn btn-secondary">Link to Dynamic Simulations</a>
+        <button onclick="buttonAction()" class="text-white btn btn-secondary">Link to Dynamic Simulations</button>
         {% endif %}
       </div>
       {% if file_contents %}
@@ -78,6 +78,22 @@
   <div id="table-drilldown-container"></div>
   <div class="push"></div>
 </div>
+  <div class="modal fade" id="block-link-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="myModalLabel">Dynamic Simulation Link Unavailable</h4>
+        </div>
+        <div class="modal-body">
+          Oops. Your simulation already had behavioral parameters. You can't link this simulation to a dynamic simulation.
+        </div>
+        <div class="modal-footer">
+          <a type="button" class="btn btn-default" data-dismiss="modal">Got it.</a>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block bottom_scripts %}
@@ -86,4 +102,15 @@
 <script src="{% static 'js/vendor/backbone/backbone-min.js' %}"></script>
 <script src="{% static 'js/vendor/DataTables/datatables.js' %}"></script>
 <script src="{% static 'js/taxbrain-tablebuilder.js' %}"></script>
+<script>
+    function buttonAction() {
+        if ({{allow_dyn_links|yesno:"true,false,true"}} ) {
+            window.location.href = "/dynamic/{{ unique_url.pk }}/?start_year={{ first_year }}";
+            } else {
+            $('#block-link-modal').modal('show');
+        }
+    }
+</script>
+
+
 {% endblock %}

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -795,7 +795,8 @@ def behavior_results(request, pk):
             return render_to_response('taxbrain/failed.html')
 
         if all([job == 'YES' for job in jobs_ready]):
-            model.tax_result = dropq_compute.dropq_get_results(normalize(job_ids))
+            results, reform_style = dropq_compute.dropq_get_results(normalize(job_ids))
+            model.tax_result = results
             model.creation_date = datetime.datetime.now()
             model.save()
             return redirect('behavior_results', url.pk)

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -242,6 +242,8 @@ class DropqCompute(object):
             fiscal_tot_base.update(result['fiscal_tot_base'])
             fiscal_tot_ref.update(result['fiscal_tot_ref'])
 
+        reform_style = ans[0].get('reform_style', None)
+
 
         if ENFORCE_REMOTE_VERSION_CHECK:
             versions = [r.get('taxcalc_version', None) for r in ans]
@@ -271,7 +273,7 @@ class DropqCompute(object):
                 'fiscal_tot_base': fiscal_tot_base,
                 'fiscal_tot_ref': fiscal_tot_ref}
 
-        return results
+        return results, reform_style
 
     def elastic_get_results(self, job_ids):
         ans = []

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -152,6 +152,7 @@ class TaxSaveInputs(models.Model):
     II_em_ps_cpi = models.NullBooleanField(default=None, blank=True, null=True)
 
     # Parameters used for Standard Deductions.
+    STD_Dep = CommaSeparatedField(default=None, blank=True, null=True)
     STD_0 = CommaSeparatedField(default=None, blank=True, null=True)
     STD_1 = CommaSeparatedField(default=None, blank=True, null=True)
     STD_2 = CommaSeparatedField(default=None, blank=True, null=True)
@@ -445,6 +446,9 @@ class TaxSaveInputs(models.Model):
 
     # Result
     tax_result = JSONField(default=None, blank=True, null=True)
+
+    # Reform style
+    reform_style = CommaSeparatedField(default=None, blank=True, null=True)
 
     # JSON input text
     json_text = models.ForeignKey(JSONReformTaxCalculator, null=True, default=None, blank=True)


### PR DESCRIPTION
 - A file-based reform could have behavioral parameters. If this is the
   case, you should not be able to launch a dynamic simulation.
 - Adds a modal pop-up if user clicks Link to Dyn. Sims on results page
   for file based reform that includes behavior parameters.
 - Behavior is unchanged if file based reform contains no behavioral
   components
 - Depends on change to worker node
 - Resolves #431