### PR TITLE
Refactor taxbrain/file to handle two file inputs

### DIFF
--- a/templates/taxbrain/includes/params/inputs/file.html
+++ b/templates/taxbrain/includes/params/inputs/file.html
@@ -13,9 +13,11 @@
   {% endblock %}
 </div>
 
-<p><label for="id_docfile">Select a file:</label> </p>
-
+<p><label for="id_docfile">Select a reform file:</label> </p>
 <p><input id="id_docfile" name="docfile" type="file" /></p>
+
+<p><label for="id_assumpfile">Select an economic assumptions file:</label> </p>
+<p><input id="id_assumpfile" name="assumpfile" type="file" /></p>
 
 {% endblock %}
 

--- a/templates/taxbrain/results.html
+++ b/templates/taxbrain/results.html
@@ -53,21 +53,24 @@
     {% endif %}
     <div class="result-table">
       <div class="result-table-controls">
-        {% if is_micro and not file_contents %}
+        {% if is_micro and not reform_file_contents %}
         <a href="/taxbrain/edit/{{ unique_url.pk }}/?start_year={{ first_year }}" class="text-white btn btn-secondary">Edit Parameters</a>
         {% endif %}
-        {% if is_behavior and not file_contents %}
+        {% if is_behavior and not reform_file_contents %}
         <a href="/dynamic/behavioral/edit/{{ unique_url.pk }}/?start_year={{ first_year }}" class="text-white btn btn-secondary">Edit Parameters</a>
         {% endif %}
         {% if is_micro %}
         <button onclick="buttonAction()" class="text-white btn btn-secondary">Link to Dynamic Simulations</button>
         {% endif %}
       </div>
-      {% if file_contents %}
-      <h2> The following reform file was uploaded for this simulation: </h2>
+      {% if reform_file_contents %}
+      <h2> The following reform files were uploaded for this simulation: </h2>
       <div class="file-contents">
           {%autoescape off %}
-          {{file_contents | linebreaks | safe }}
+          {{reform_file_contents | linebreaks | safe }}
+          {%endautoescape %}
+          {%autoescape off %}
+          {{assump_file_contents | linebreaks | safe }}
           {%endautoescape %}
        </div>
       {% endif %}

--- a/webapp/apps/dynamic/tests/utils.py
+++ b/webapp/apps/dynamic/tests/utils.py
@@ -45,6 +45,7 @@ def do_micro_sim_from_file(client, fname):
 
     tc_file = SimpleUploadedFile(fname, "file_content")
     data = {u'docfile': tc_file,
+            u'assumpfile': tc_file,
             u'has_errors': [u'False'],
             u'start_year': unicode(START_YEAR), 'csrfmiddlewaretoken':'abc123'}
 

--- a/webapp/apps/dynamic/views.py
+++ b/webapp/apps/dynamic/views.py
@@ -125,7 +125,7 @@ def dynamic_input(request, pk):
                 # start calc job
                 submitted_ids, guids = dynamic_compute.submit_ogusa_calculation(worker_data, int(start_year), microsim_data)
             else:
-                microsim_data = taxbrain_model.json_text.text
+                microsim_data = {"reform": taxbrain_model.json_text.reform_text, "assumptions": taxbrain_model.json_text.assumption_text}
                 # start calc job
                 submitted_ids, guids = dynamic_compute.submit_json_ogusa_calculation(worker_data,
                                                                          int(start_year),
@@ -233,7 +233,7 @@ def dynamic_behavioral(request, pk):
                 submitted_ids, max_q_length = dropq_compute.submit_dropq_calculation(microsim_data, int(start_year))
 
             else:
-                microsim_data = taxbrain_model.json_text.text
+                microsim_data = {"reform": taxbrain_model.json_text.reform_text, "assumptions": taxbrain_model.json_text.assumption_text}
                 el_keys = ('first_year', 'elastic_gdp')
                 behavior_params = { k:v for k, v in worker_data.items() if k in el_keys}
                 behavior_params = { k:v for k, v in worker_data.items()
@@ -367,7 +367,7 @@ def dynamic_elasticities(request, pk):
                                                                         int(start_year))
 
             else:
-                microsim_data = taxbrain_model.json_text.text
+                microsim_data = {"reform": taxbrain_model.json_text.reform_text, "assumptions": taxbrain_model.json_text.assumption_text}
                 el_keys = ('first_year', 'elastic_gdp')
                 elasticity_params = { k:v for k, v in worker_data.items() if k in el_keys}
                 additional_data = {'elasticity_params': json.dumps(elasticity_params)}

--- a/webapp/apps/taxbrain/migrations/0041_auto_20170126_0317.py
+++ b/webapp/apps/taxbrain/migrations/0041_auto_20170126_0317.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('taxbrain', '0040_taxsaveinputs_id_benefitsurtax_em'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='jsonreformtaxcalculator',
+            old_name='text',
+            new_name='reform_text',
+        ),
+        migrations.AddField(
+            model_name='jsonreformtaxcalculator',
+            name='assumption_text',
+            field=models.CharField(max_length=4000, blank=True),
+        ),
+    ]

--- a/webapp/apps/taxbrain/models.py
+++ b/webapp/apps/taxbrain/models.py
@@ -78,7 +78,8 @@ class JSONReformTaxCalculator(models.Model):
     an instance of this model if the user created the TaxBrain job
     through the JSON iput page.
     '''
-    text = models.CharField(blank=True, null=False, max_length=4000)
+    reform_text = models.CharField(blank=True, null=False, max_length=4000)
+    assumption_text = models.CharField(blank=True, null=False, max_length=4000)
 
 class ErrorMessageTaxCalculator(models.Model):
     '''

--- a/webapp/apps/taxbrain/tests/test_all.py
+++ b/webapp/apps/taxbrain/tests/test_all.py
@@ -185,14 +185,14 @@ class TaxInputTests(TestCase):
     def test_package_up_vars_wildcards_2016(self):
         values = {"SS_Earnings_c": ['*','*',230000.]}
         ans = package_up_vars(values, first_budget_year=2016)
-        exp =  [118500., 124176, 230000.]
+        exp =  [118500., 124093, 230000.]
         assert ans['_SS_Earnings_c'] == exp
 
 
     def test_package_up_vars_wildcards_2019(self):
         values = {"SS_Earnings_c": ['*','*','*', 400000.]}
         ans = package_up_vars(values, first_budget_year=2016)
-        exp =  [118500., 124176, 129652, 400000. ]
+        exp =  [118500., 124093, 129503, 400000. ]
         assert ans['_SS_Earnings_c'] == exp
 
 

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -522,7 +522,26 @@ class TaxBrainViewsTests(TestCase):
         assert float(tsi2.PT_brk7_3) == float(tsi2.II_brk7_3)
 
 
-    def test_taxbrain_file_post(self):
+    def test_taxbrain_file_post_only_reform(self):
+        #Monkey patch to mock out running of compute jobs
+        import sys
+        webapp_views = sys.modules['webapp.apps.taxbrain.views']
+        webapp_views.dropq_compute = MockCompute()
+        tc_file = SimpleUploadedFile("test_reform.json", "file_content")
+        data = {u'docfile': tc_file,
+                u'has_errors': [u'False'],
+                u'start_year': unicode(START_YEAR), 'csrfmiddlewaretoken':'abc123'}
+
+        response = self.client.post('/taxbrain/file/', data)
+        # Check that redirect happens
+        self.assertEqual(response.status_code, 302)
+        # Go to results page
+        link_idx = response.url[:-1].rfind('/')
+        self.failUnless(response.url[:link_idx+1].endswith("taxbrain/"))
+
+
+
+    def test_taxbrain_file_post_reform_and_assumptions(self):
         #Monkey patch to mock out running of compute jobs
         import sys
         webapp_views = sys.modules['webapp.apps.taxbrain.views']

--- a/webapp/apps/taxbrain/tests/test_views.py
+++ b/webapp/apps/taxbrain/tests/test_views.py
@@ -528,7 +528,9 @@ class TaxBrainViewsTests(TestCase):
         webapp_views = sys.modules['webapp.apps.taxbrain.views']
         webapp_views.dropq_compute = MockCompute()
         tc_file = SimpleUploadedFile("test_reform.json", "file_content")
+        tc_file2 = SimpleUploadedFile("test_assumptions.json", "file_content")
         data = {u'docfile': tc_file,
+                u'assumpfile': tc_file2,
                 u'has_errors': [u'False'],
                 u'start_year': unicode(START_YEAR), 'csrfmiddlewaretoken':'abc123'}
 

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -240,21 +240,19 @@ def file_input(request):
         do_full_calc = False if fields.get('quick_calc') else True
         error_messages = {}
         reform_dict = {}
-        if 'docfile' in request.FILES and 'assumpfile' in request.FILES:
+        if 'docfile' in request.FILES:
             inmemfile_reform = request.FILES['docfile']
             reform_text = inmemfile_reform.read().strip()
             reform_dict['taxcalc_reform'] = reform_text
-            inmemfile_assumption = request.FILES['assumpfile']
-            assumption_text = inmemfile_assumption.read().strip()
-            reform_dict['taxcalc_assumption'] = assumption_text
-        else:
-            if 'docfile' in request.FILES:
-                msg = "No assumption file uploaded."
-            elif 'assumpfile' in request.FILES:
-                msg = "No reform file uploaded."
+            if 'assumpfile' in request.FILES:
+                inmemfile_assumption = request.FILES['assumpfile']
+                assumption_text = inmemfile_assumption.read().strip()
+                reform_dict['taxcalc_assumption'] = assumption_text
             else:
-                msg = "No reform file or assumption file uploaded."
+                reform_dict['taxcalc_assumption'] = ""
 
+        else:
+            msg = "No reform file uploaded."
             error_messages['Tax-Calculator:'] = msg
 
         if error_messages:

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -240,12 +240,22 @@ def file_input(request):
         do_full_calc = False if fields.get('quick_calc') else True
         error_messages = {}
         reform_dict = {}
-        if 'docfile' in request.FILES:
-            inmemfile = request.FILES['docfile']
-            text_taxcalc = inmemfile.read().strip()
-            reform_dict['taxcalc'] = text_taxcalc
+        if 'docfile' in request.FILES and 'assumpfile' in request.FILES:
+            inmemfile_reform = request.FILES['docfile']
+            reform_text = inmemfile_reform.read().strip()
+            reform_dict['taxcalc_reform'] = reform_text
+            inmemfile_assumption = request.FILES['assumpfile']
+            assumption_text = inmemfile_assumption.read().strip()
+            reform_dict['taxcalc_assumption'] = assumption_text
         else:
-            error_messages['Tax-Calculator:'] = "No file uploaded."
+            if 'docfile' in request.FILES:
+                msg = "No assumption file uploaded."
+            elif 'assumpfile' in request.FILES:
+                msg = "No reform file uploaded."
+            else:
+                msg = "No reform file or assumption file uploaded."
+
+            error_messages['Tax-Calculator:'] = msg
 
         if error_messages:
             has_errors = True
@@ -253,18 +263,22 @@ def file_input(request):
         else:
             try:
                 log_ip(request)
+                mods = { 'reform': reform_dict['taxcalc_reform'], 'assumptions': reform_dict['taxcalc_assumption']}
                 #Submit calculation
                 if do_full_calc:
-                    submitted_ids, max_q_length = dropq_compute.submit_json_dropq_calculation(reform_dict['taxcalc'], int(start_year))
+                    submitted_ids, max_q_length = dropq_compute.submit_json_dropq_calculation(mods,
+                                                                                              int(start_year))
                 else:
-                    submitted_ids, max_q_length = dropq_compute.submit_json_dropq_small_calculation(reform_dict['taxcalc'], int(start_year))
+                    submitted_ids, max_q_length = dropq_compute.submit_json_dropq_small_calculation(mods,
+                                                                                                    int(start_year))
 
                 if not submitted_ids:
                     raise JobFailError("couldn't submit ids")
                 else:
                     job_ids = denormalize(submitted_ids)
                     json_reform = JSONReformTaxCalculator()
-                    json_reform.text = reform_dict['taxcalc']
+                    json_reform.reform_text = reform_dict['taxcalc_reform']
+                    json_reform.assumption_text = reform_dict['taxcalc_assumption']
                     json_reform.save()
 
                     model = TaxSaveInputs()
@@ -499,10 +513,13 @@ def get_result_context(model, request, url):
     }
 
     if model.json_text:
-        file_contents = model.json_text.text
-        file_contents = file_contents.replace(" ","&nbsp;")
+        reform_file_contents = model.json_text.reform_text
+        reform_file_contents = reform_file_contents.replace(" ","&nbsp;")
+        assump_file_contents = model.json_text.assumption_text
+        assump_file_contents = assump_file_contents.replace(" ","&nbsp;")
     else:
-        file_contents = False
+        reform_file_contents = False
+        assump_file_contents = False
 
     if hasattr(request, 'user'):
         is_registered = True if request.user.is_authenticated() else False
@@ -523,7 +540,8 @@ def get_result_context(model, request, url):
         'quick_calc': quick_calc,
         'is_registered': is_registered,
         'is_micro': True,
-        'file_contents': file_contents,
+        'reform_file_contents': reform_file_contents,
+        'assump_file_contents': assump_file_contents,
         'allow_dyn_links': allow_dyn_links
     }
     return context


### PR DESCRIPTION
 - One file input for the reform, one for assumptions
 - Migrate data model so JSON input has reform_text, assumption_text
 - Handle error cases of 0 or only 1 reform file provided
 - Instead of passing arbitrary string text in POST, provide dictionary
   of the form { "reform": string, "assumptions": string}
 - Necessary change for taxcalc 0.7.4
 - Update some hard-coded test data since values in taxcalc changed