### PR TITLE
Fix cell index ccc

### DIFF
--- a/templates/btax/results.html
+++ b/templates/btax/results.html
@@ -231,7 +231,7 @@
 					<th colspan="2">Debt Financed</th>
 				  </tr>
 				  <tr>
-					<th scope="col">Corporate</th>
+                    <th scope="col">Corporate</th>
 					<th scope="col">Non-corporate</th>
 					<th scope="col">Corporate</th>
 					<th scope="col">Non-corporate</th>
@@ -264,6 +264,9 @@
                             <td class="data-label">
                                 <strong>${row.label}</strong>
                             </td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
                             <td></td>
                             <td></td>
                             <td></td>


### PR DESCRIPTION
We were seeing Javascript errors in loading `/ccc` results page.  The errors related to index errors in datatables.js.  This PR ensures every row added to table has the same number of <tr><td> elements and thus avoids index error  in datatables.js