### PR TITLE
update docs

### DIFF
--- a/templates/pages/docs.html
+++ b/templates/pages/docs.html
@@ -13,45 +13,87 @@
   <div class="col-xs-3">
     <div class="inputs-sidebar docs-links">
       <ul class="nav sidebar-nav">
-        <li><a href="#lorem">Lorem</a></li>
-        <li><a href="#ipsum">Ipsum</a></li>
-        <li><a href="#dolor">Dolor</a></li>
-        <li><a href="#sit">Sit</a></li>
-        <li><a href="#amet">Amet</a></li>
+        <li><a href="#TaxBrain">TaxBrain</a></li>
+        <li><a href="#Disclaimer">Disclaimer</a></li>
       </ul>
     </div> <!-- sidebar -->
   </div>
   <div class="col-xs-9">
-    <div id="lorem" class="docs-section">
-      <h1>Lorem</h1>
-      <h2>Lorem</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div id="TaxBrain" class="docs-section">
+      <h1>TaxBrain</h1>
+      <h2>Overview</h2>
+      <p>TaxBrain is an interface to <a href = "//www.github.com/open-source-economics" target="_blank">open source economic models</a> for tax policy analysis. <a href = '//www.github.com/opensourcepolicycenter/webapp-public' target="_blank">The code</a> for the TaxBrain webapp interface is itself open source. </p>
+
+      <ul>
+      <li> <strong>Step 1.</strong> Create a policy reform by modifying tax law parameters such as rates and deductions, adjust the economic baseline, and request the static result. You can do so with the graphical user interface below or by uploading a policy reform file <a href = "//www.ospc.org/taxbrain/file" target="_blank">from this page</a>.</li>
+      <li><strong>Step 2.</strong> Review your static output carefully. Ask questions.</li>
+      <li><strong>Step 3.</strong> Choose a dynamic modeling approach. Because different approaches generally lead to different estimates, you may want to compare several approaches.</li>
+      <li><strong>Step 4.</strong> Adjust economic assumptions and request the dynamic analysis.</li>
+      <li><strong>Step 5.</strong> Review your dynamic output carefully. Ask questions.</li>
+      <li><strong>Step 6.</strong> Share your results! The link to every results page is static and will never change. Send them around.</li>
+      </ul>
+
+      <p> Throughout this process, if you have a question about how to use TaxBrain or interpret the results, if you want to make a suggestion for making the interface or underlying models better, or if you discover a bug, please <a href = '//list.ospc.org/mailman/listinfo/users_list.ospc.org' target="_blank">join our mailing list</a> and send a message or <a href = '//ospc.org/hello' target="_blank">leave a note for the OSPC team</a>.</p>
+
+    <h2>Static Modeling</h2>
+    <p> Static tax analysis entails computing individuals' tax changes under the assumption that behavior does not change in response to tax policy. Static analyses are useful for understanding the mechanistic effects of tax policy changes, and they form the basis to which behavior is applied for dynamic analyses. 
+
+    <p>TaxBrain's static modeling capabilities rely on several open source economic models and other packages:</p> 
+    <ul>
+    <li> <a href = "//www.github.com/open-source-economics/tax-calculator" target="_blank">Tax-Calculator</a> computes federal individual income taxes and Federal Insurance Contribution Act(FICA) taxes for a sample of tax filing units in years beginning with 2013 .</li>
+    <li><a href = '//www.github.com/open-source-economics/taxdata' target="_blank">TaxData</a> creates a microdataset that closely reproduces the multivariate distribution of income, deduction and credit items in 2009, extrapolated through 2026 levels in accordance with Congressional Budget Office forecasts available in spring 2016. It is intended to match similar but confidential data used by the Congressional Joint Committee on Taxation. The underlying dataset must be purchased from the Statistics of Income division of the Internal Revenue Service. Additional information on non-filers is taken from the March 2013 Current Population Survey. </li>
+    <li> DropQ implements a disclosure avoidance algorithm initially proposed by the U.S. Census Bureau to protect confidential data from differencing attacks. The code is undergoing security review before it is open sourced.</li>
+    <li> <a href = '//www.github.com/opensourcepolicycenter/webapp-public' target="_blank">TaxBrain</a> itself is an open source project. The underlying models are deployed to TaxBrain using conda, a free and open source package management system supported by <a href = '//www.continuum.io' target="_blank">Continuum Analytics</a></li>
+    </ul>
+
+    <p><strong>Transparency and Replicability</strong></p>
+
+    <p>In addition to relying on open source models, we are devoted to making it easy for reviewers to understand the models even if they can't understand the source code or don't have access to the underlying data. Toward that end we produce several additional reports to enhance transparency, peer review, collaboration and a scientific advancement.</p>
+
+    <p>Note that these reports currently rely on the latest versions of tax-calculator and TaxData, which might not correspond perfectly to TaxBrain.</p>
+
+    <ul>
+    <li><a href = "https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/comparison/reform_results.txt" target = "_blank">Federal income tax and FICA liability deltas for example reforms</a></li>
+    <li>Dummy datasets and associated Tax-Calculator results (Coming soon)</li> 
+    <li><a href = "https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/comparison/variable_stats_summary.csv">Basic summary statistics for variables used in Tax-Calculator and major intermediate results (2013-2026) </a></li>Currently only weighted mean is available, more statistics will be  added shortly.
+    <li><a href = "https://github.com/open-source-economics/Tax-Calculator/blob/master/taxcalc/comparison/correlation.csv" target= "_blank">Correlation matrix for the same set of variables</a> 2016 available now, other years coming soon.</li>
+    <li>Extrapolation related: <br>
+    <a href = "https://github.com/open-source-economics/taxdata/blob/master/Stage%20II/Stage_I_factors.csv" target= "_blank">Blow-up factors</a><br>
+    <a href = "https://github.com/open-source-economics/taxdata/blob/master/Stage%20II/Stage_II_targets.csv" target= "_blank">Aggregate and distributional targets</a></li> 
+    <li>Equations and coefficients for imputations (Coming soon)</li>
+    </ul>
+
+    <p><strong>Accuracy notes</strong></p>
+
+    <p>The Python code that performs the tax calculations has been validated in a
+    number of ways.  First, Tax-Calculator results for a number of tax filing
+    units have been compared to hand calculations performed using IRS tax
+    forms.  Second, Tax-Calculator results for a large sample of tax filing units
+    have been compared to results for the same sample generated by a
+    <a href = '//www.nber.org/taxcalc' target="_blank">detailed SAS program</a> developed by Dan
+    Feenberg and Ina Shapiro of NBER.  Third, a subset of input variables has been used to compare the results of Tax-Calculator to <a href = '//users.nber.org/~taxsim' target="_blank">Internet TAXSIM</a> as well as against the Policy Simulation Group's <a href = '//www.polsim.com/inctax-caps.html' target="_blank">PENSIM tax module</a></p>
+
+    <p> Bugs aside, the static modelingresults from TaxBrain might differ in comparison to those produced by Congress or the Administration for other reasons. Modeling requires many assumptions, and neither Congress nor the executive branch publicize all of their assumptions. For example, the distribution of wages in <a href = '//www.github.com/open-source-economics/taxdata' target="_blank">TaxData</a> is assumed to stay the same in real terms for all years after the last year we have available data (2013). We know that Congress assumes this distribution changes over time, but it doesn't publish by how much. These assumptions are all flexible in <a href = '//www.github.com/open-source-economics/taxdata' target="_blank">TaxData</a>, so please conduct sensitivity analyses. Other assumptions can be made flexible in TaxBrain based on user requests.</p>
+
+    <p><strong> 
+    Core Maintainers (static modeling)*:
+    <ul style = "list-style-type:none">
+    <li>- <a href = "http://www.nber.org/people/daniel_feenberg" target = "blank" >Dan Feenberg</a></li> 
+    <li>- <a href = "https://github.com/andersonfrailey" target = "blank" >Anderson Frailey</a></li> 
+    <li>- <a href = "http://www.polsim.com/MRH_vita.pdf" target = "blank" >Martin Holmer</a></li> 
+    <li>- <a href = "https://www.aei.org/scholar/matthew-h-jensen/" target = "blank" >Matt Jensen</a></li> 
+    <li>- <a href = "http://quantria.com/#team" target = "blank" >John O'Hare</a></li> 
+    <li>- <a href = "https://github.com/Amy-Xu" target = "blank" >Amy Xu</a></li> 
+    </ul>
+    </strong></p> 
+    <p> *These members have "write access" to one or both of the core static modeling repositories, Tax-Calculator and TaxData, and work as a team to determine which open source contributions are accepted.</p>
+
     </div>
-    <div id="ipsum" class="docs-section">
-      <h1>Ipsum</h1>
-      <h2>Ipsum</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div id="Disclaimer" class="docs-section">
+    <h1>Disclaimer</h1>
+      <p>Proper use of ospc.org tools and description of that use is ultimately your responsibility. If you plan on publishing your results, it is recommended that you confirm with the community that you are using the tools properly and interpreting the results correctly before you publish them.</p>
+      <p>Results will change as the underlying models improve. A fundamental reason for adopting open source methods in this project is to let people from all backgrounds contribute to the models that our society uses to assess economic policy; when community-contributed improvements are incorporated, the models will produce different results.</p>
+      <p>Neither the Open Source Policy Center nor the American Enterprise Institute maintain institutional positions, and the results from models accessible via the ospc.org interfaces should not be attributed to OSPC or AEI.</p>
     </div>
-    <div id="dolor" class="docs-section">
-      <h1>Dolor</h1>
-      <h2>Dolor</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </div>
-    <div id="sit" class="docs-section">
-      <h1>Sit</h1>
-      <h2>Sit</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </div>
-    <div id="amet" class="docs-section">
-      <h1>Amet</h1>
-      <h2>Amet</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    </div>
-  </div>
-</div>
+    
 {% endblock %}


### PR DESCRIPTION
Enables #457. 

@jdebacker @rickecon:

I am moving documentation text from the taxbrain static input page and into docs.html. From the TaxBrain input page, I'll have a bullet point: "feedback | modeling notes |  disclaimer" 

"Feedback" will link to ospc.org/hello, ([test site version](http://ospc-taxes7.herokuapp.com/hello/))
"Modeling notes" will link to the static modeling section of the docs.html. See the diff in this PR. 
"Disclaimer" will link to the disclaimer section of docs.html. See the diff in this PR. 

Feel free to move or replicate any content from the overlapping generations page or the CCC page into new sections of docs.html if you would like. I don't see any urgency, but it's a nice new option. 


