### PR TITLE
fix btax result endpoint so not expecting taxcalc keys

### DIFF
--- a/webapp/apps/btax/compute.py
+++ b/webapp/apps/btax/compute.py
@@ -68,6 +68,9 @@ class DropqComputeBtax(DropqCompute):
                                        increment_counter=False,
                                        use_wnc_offset=False)
 
+    def btax_get_results(self, job_ids, job_failure=False):
+        return self._get_results_base(job_ids, job_failure=job_failure)
+
 
 class MockComputeBtax(MockCompute, DropqComputeBtax):
     num_budget_years = 1

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -367,7 +367,7 @@ def output_detail(request, pk):
                            zip(jobs_to_check, jobs_ready) if job_ready == 'FAIL']
 
             #Just need the error message from one failed job
-            error_msgs = dropq_compute.dropq_get_results([failed_jobs[0]], job_failure=True)
+            error_msgs = dropq_compute.btax_get_results([failed_jobs[0]], job_failure=True)
             error_msg = error_msgs[0]
             val_err_idx = error_msg.rfind("Error")
             context = {"error_msg": error_msg[val_err_idx:],
@@ -377,7 +377,7 @@ def output_detail(request, pk):
 
 
         if all([job == 'YES' for job in jobs_ready]):
-            model.tax_result = dropq_compute.dropq_get_results(normalize(job_ids))
+            model.tax_result = dropq_compute.btax_get_results(normalize(job_ids))
 
             model.creation_date = datetime.datetime.now()
             print 'ready'

--- a/webapp/apps/btax/views.py
+++ b/webapp/apps/btax/views.py
@@ -367,7 +367,7 @@ def output_detail(request, pk):
                            zip(jobs_to_check, jobs_ready) if job_ready == 'FAIL']
 
             #Just need the error message from one failed job
-            error_msgs = dropq_compute.btax_get_results([failed_jobs[0]], job_failure=True)
+            error_msgs = dropq_compute.dropq_get_results([failed_jobs[0]], job_failure=True)
             error_msg = error_msgs[0]
             val_err_idx = error_msg.rfind("Error")
             context = {"error_msg": error_msg[val_err_idx:],


### PR DESCRIPTION
 * Btax results were being given to a compute.py dropq_get_results function that was expecting non-B-Tax keys (taxbrain - taxcalc specific keys)
 * This PR fixes that endpoint - I think the broken endpoint on results was causing our hanging behavior on heroku recently with /ccc