### PR TITLE
Remove Year "( 2017 )" in the Total Liability Table

### DIFF
--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -581,8 +581,8 @@ $(function() {
 
     // mock data --------------------
     tablesObj['fiscal_change'] = JSON.parse(JSON.stringify(tablesObj['fiscal_change']));
-    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
-    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)';
+    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)';
 
     tablesObj['fiscal_currentlaw'] =  JSON.parse(JSON.stringify(tablesObj['fiscal_currentlaw']));
     tablesObj['fiscal_currentlaw']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CURRENT LAW)';

--- a/static/js/taxbrain-tablebuilder.js
+++ b/static/js/taxbrain-tablebuilder.js
@@ -207,7 +207,7 @@ $(function() {
                     <table class="table table-striped" style="width:100%">\
                         <thead>\
                             <tr>\
-                                <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %><% if (model.get("reference") !== "fiscal_reform") { %> (<%= model.get("year") %>)<% } %></h1></th>\
+                                <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\
                             </tr>\
                             <tr>\
                                 <th></th>\
@@ -581,8 +581,8 @@ $(function() {
 
     // mock data --------------------
     tablesObj['fiscal_change'] = JSON.parse(JSON.stringify(tablesObj['fiscal_change']));
-    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES CHANGE BY CALENDAR YEAR';
-    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES CHANGE BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
 
     tablesObj['fiscal_currentlaw'] =  JSON.parse(JSON.stringify(tablesObj['fiscal_currentlaw']));
     tablesObj['fiscal_currentlaw']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CURRENT LAW)';

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -581,8 +581,8 @@ $(function() {
 
     // mock data --------------------
     tablesObj['fiscal_change'] = JSON.parse(JSON.stringify(tablesObj['fiscal_change']));
-    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
-    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)';
+    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)';
 
     tablesObj['fiscal_currentlaw'] =  JSON.parse(JSON.stringify(tablesObj['fiscal_currentlaw']));
     tablesObj['fiscal_currentlaw']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CURRENT LAW)';

--- a/staticfiles/js/taxbrain-tablebuilder.js
+++ b/staticfiles/js/taxbrain-tablebuilder.js
@@ -207,7 +207,7 @@ $(function() {
                     <table class="table table-striped" style="width:100%">\
                         <thead>\
                             <tr>\
-                                <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %><% if (model.get("reference") !== "fiscal_reform") { %> (<%= model.get("year") %>)<% } %></h1></th>\
+                                <th class="text-center" colspan="<%= model.get("cols").length + 1 %>"><h1><%= model.get("label").toUpperCase() %></h1></th>\
                             </tr>\
                             <tr>\
                                 <th></th>\
@@ -581,8 +581,8 @@ $(function() {
 
     // mock data --------------------
     tablesObj['fiscal_change'] = JSON.parse(JSON.stringify(tablesObj['fiscal_change']));
-    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES CHANGE BY CALENDAR YEAR';
-    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES CHANGE BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
+    tablesObj['fiscal_change']['label'] =  'TOTAL LIABILITIES BY CALENDAR YEAR';
 
     tablesObj['fiscal_currentlaw'] =  JSON.parse(JSON.stringify(tablesObj['fiscal_currentlaw']));
     tablesObj['fiscal_currentlaw']['title'] =  'TOTAL LIABILITIES BY CALENDAR YEAR (CURRENT LAW)';


### PR DESCRIPTION
In [#534](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/534#issuecomment-296374906), @MattHJensen suggested:
>TOTAL LIABILITIES TABLES: Should not include the year in the table name. Currently the "Change" and "Current Law" tables include the start year in parenthesis.

as well as 
>TOTAL LIABILITIES CHANGE TABLE: TOTAL LIABILITIES CHANGE BY CALENDAR YEAR (2017) should be TOTAL LIABILITIES BY CALENDAR YEAR (CHANGE)

This PR addresses these two concerns. After the fix, the table will look like the following:

For Current Law:
![screen shot 2017-06-19 at 6 53 29 pm](https://user-images.githubusercontent.com/13324931/27309438-c5205d62-5521-11e7-9fab-fb1ef05aa6c0.png)

For Reform:
![screen shot 2017-06-19 at 6 53 21 pm](https://user-images.githubusercontent.com/13324931/27309439-c521fbf4-5521-11e7-82d4-1c81b45f3bf7.png)

And for Difference:
![screen shot 2017-06-19 at 6 53 13 pm](https://user-images.githubusercontent.com/13324931/27309440-c5222cbe-5521-11e7-9fdd-3eae5b03e30c.png)

Could you review? @MattHJensen @brittainhard 
