### PR TITLE
Change Title Terminology for Tables

### DIFF
--- a/webapp/apps/taxbrain/helpers.py
+++ b/webapp/apps/taxbrain/helpers.py
@@ -225,13 +225,13 @@ TAXCALC_RESULTS_DEC_ROW_KEY_LABELS = {
     'all':'All'
 }
 TAXCALC_RESULTS_TABLE_LABELS = {
-    'mX_dec': 'Base plan tax vars, weighted total per expanded income decile',
-    'mY_dec': 'User plan tax vars, weighted total per expanded income decile',
+    'mX_dec': 'Base plan tax vars, weighted total by expanded income decile',
+    'mY_dec': 'User plan tax vars, weighted total by expanded income decile',
     'df_dec': 'Individual Income Tax: Difference between Base and User plans by expanded income decile',
     'pdf_dec': 'Payroll Tax: Difference between Base and User plans by expanded income decile',
     'cdf_dec': 'Combined Payroll and Individual Income Tax: Difference between Base and User plans by expanded income decile',
-    'mX_bin': 'Base plan tax vars, weighted total per expanded income bin',
-    'mY_bin': 'User plan tax vars, weighted total per expanded income bin',
+    'mX_bin': 'Base plan tax vars, weighted total by expanded income bin',
+    'mY_bin': 'User plan tax vars, weighted total by expanded income bin',
     'df_bin': 'Individual Income Tax: Difference between Base and User plans by expanded income bin',
     'pdf_bin': 'Payroll Tax: Difference between Base and User plans by expanded income bin',
     'cdf_bin': 'Combined Payroll and Individual Income Tax: Difference between Base and User plans by expanded income bin',


### PR DESCRIPTION
As discussed in [#534](https://github.com/OpenSourcePolicyCenter/webapp-public/issues/534#issuecomment-296374906), the terminology for the diagnostic tables and the difference tables are different. 

The is old title name:
<img width="807" alt="screen shot 2017-06-20 at 5 00 22 pm" src="https://user-images.githubusercontent.com/13324931/27355706-fad4feb4-55d9-11e7-93af-2e548139a253.png">

This is the title name proposed in this PR:
<img width="867" alt="screen shot 2017-06-20 at 5 00 11 pm" src="https://user-images.githubusercontent.com/13324931/27355708-fad90e50-55d9-11e7-820d-2cbe7d8494b8.png">

All "Per" are changed to "By" so that the diagnostic tables and the difference tables have consistent title names. 

@brittainhard @MattHJensen Could you review?
