### PR TITLE
File Upload Fixes

### DIFF
--- a/deploy/taxbrain_server/celery_tasks.py
+++ b/deploy/taxbrain_server/celery_tasks.py
@@ -60,18 +60,14 @@ def dropq_task(year, user_mods, first_budget_year, beh_params, tax_data):
     # index indicates whether the reform dictionary was non-empty
     # The four reform dictionaries from file-based reforms are:
     # policy, behavior, growth, consumption (in that order)
-    reform_style = [True]
-    if first_budget_year is not None:
-        first_year = int(first_budget_year)
-    else:
-        first_year = int(user_mods.keys()[0])
-
+    first_budget_year = int(first_budget_year)
     user_mods = convert_int_key(user_mods)
-    print('first_year', first_year)
-    if user_mods.get(first_year):
-        for key in set(user_mods[first_year]):
-            if key.startswith('_BE_'):
-                user_mods[first_year].pop(key)
+    print('first_year', first_budget_year)
+    for reform_year in user_mods.keys():
+        if user_mods.get(reform_year):
+            for key in set(user_mods[reform_year]):
+                if key.startswith('_BE_'):
+                    user_mods[reform_year].pop(key)
         user_reform = {"policy": user_mods}
     print('user_reform', user_reform, user_mods)
     reform_style = [True if x else False for x in user_reform]
@@ -84,7 +80,7 @@ def dropq_task(year, user_mods, first_budget_year, beh_params, tax_data):
     for key in EXPECTED_KEYS:
         if key not in user_reform:
             user_reform[key] = {}
-    kw = dict(year_n=year, start_year=first_year,
+    kw = dict(year_n=year, start_year=first_budget_year,
               taxrec_df=tax_data, user_mods=user_reform)
     print('keywords to dropq', {k: v for k, v in kw.items()
                                 if k not in ('taxrec_df',)})

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -118,7 +118,8 @@ class DropqCompute(object):
         hostnames = workers[dropq_worker_offset: dropq_worker_offset + num_years]
         print "hostnames: ", hostnames
         num_hosts = len(hostnames)
-        data['user_mods'] = json.dumps(user_mods)
+        data["user_mods"] = json.dumps(user_mods)
+        data["first_budget_year"] = str(first_budget_year)
         if additional_data:
             if "behavior" in additional_data.keys():
                 data["behavior_params"] = json.dumps(additional_data)

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -118,6 +118,7 @@ class DropqCompute(object):
         hostnames = workers[dropq_worker_offset: dropq_worker_offset + num_years]
         print "hostnames: ", hostnames
         num_hosts = len(hostnames)
+        data['first_budget_year'] = json.dumps(first_budget_year)
         data['user_mods'] = json.dumps(user_mods)
         if additional_data:
             if "behavior" in additional_data.keys():

--- a/webapp/apps/taxbrain/compute.py
+++ b/webapp/apps/taxbrain/compute.py
@@ -118,7 +118,6 @@ class DropqCompute(object):
         hostnames = workers[dropq_worker_offset: dropq_worker_offset + num_years]
         print "hostnames: ", hostnames
         num_hosts = len(hostnames)
-        data['first_budget_year'] = json.dumps(first_budget_year)
         data['user_mods'] = json.dumps(user_mods)
         if additional_data:
             if "behavior" in additional_data.keys():

--- a/webapp/apps/taxbrain/tests/test_compute.py
+++ b/webapp/apps/taxbrain/tests/test_compute.py
@@ -18,6 +18,7 @@ SUBMIT_DROPQ_DATA = {
     "url_template": 'http://{hn}/dropq_start_job',
     "additional_data": {'growdiff_response': {}, 'consumption': {}, 'behavior': {}, 'growdiff_baseline': {}},
     "is_file": True
+}
 
 
 class MockComputeTests(MockCompute):

--- a/webapp/apps/taxbrain/tests/test_compute.py
+++ b/webapp/apps/taxbrain/tests/test_compute.py
@@ -1,0 +1,47 @@
+import mock
+import json
+
+from django.test import TestCase
+from django.test import Client
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.client import RequestFactory
+
+from .. import compute
+from ..compute import DropqCompute, MockCompute
+from ...test_assets import *
+import requests_mock
+
+
+SUBMIT_DROPQ_DATA = {
+    "mods": {2018: {u'_SS_Earnings_c': [400000], u'_II_em_cpi': False, u'_II_em': [8000]}, 2019: {u'_SS_Earnings_c': [500000], u'_ALD_InvInc_ec_rt': [0.2]}, 2020: {u'_SS_Earnings_c': [600000], u'_II_em_cpi': True}},
+    "first_budget_year": 2013,
+    "url_template": 'http://{hn}/dropq_start_job',
+    "additional_data": {'growdiff_response': {}, 'consumption': {}, 'behavior': {}, 'growdiff_baseline': {}},
+    "is_file": True
+
+
+class MockComputeTests(MockCompute):
+
+    def remote_submit_job(self, theurl, data, timeout):
+        assert "first_budget_year" in data.keys()
+        return super(MockComputeTests, self).remote_submit_job(theurl, data, timeout)
+
+
+class ComputeTests(TestCase):
+    ''' Test the views of this app. '''
+
+    def setUp(self):
+        # Every test needs a client.
+        self.dropq_compute = MockComputeTests()
+        # self.dropq_compute.remote_submit_job = MockCompute().remote_submit_job
+        self.client = Client()
+
+    def test_submit_calculation(self):
+        self.dropq_compute.submit_calculation(
+            SUBMIT_DROPQ_DATA["mods"],
+            SUBMIT_DROPQ_DATA["first_budget_year"],
+            SUBMIT_DROPQ_DATA["url_template"],
+            num_years=1,
+            additional_data=SUBMIT_DROPQ_DATA["additional_data"],
+            pack_up_user_mods=False
+        )

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -228,7 +228,6 @@ def file_input(request):
             reform_file = tempfile.NamedTemporaryFile(delete=False)
             reform_file.write(reform_text)
             reform_file.close()
-            os.remove(reform_file.name)
             if 'assumpfile' in request.FILES:
                 inmemfile_assumption = request.FILES['assumpfile']
                 assumptions_text = inmemfile_assumption.read()
@@ -236,7 +235,6 @@ def file_input(request):
                 assumptions_file.write(assumptions_text)
                 assumptions_file.close()
                 reform_dict = taxcalc.Calculator.read_json_param_files(reform_file.name, assumptions_file.name, arrays_not_lists=False)
-                os.remove(assumptions_file.name)
             else:
                 assumptions_text = ""
                 reform_dict = taxcalc.Calculator.read_json_param_files(reform_file.name, None, arrays_not_lists=False)
@@ -244,7 +242,6 @@ def file_input(request):
         else:
             msg = "No reform file uploaded."
             error_messages['Tax-Calculator:'] = msg
-
         reforms = reform_dict["policy"]
         assumptions = {k: v for k, v in reform_dict.items() if k != "policy"}
         if error_messages:

--- a/webapp/apps/taxbrain/views.py
+++ b/webapp/apps/taxbrain/views.py
@@ -228,6 +228,7 @@ def file_input(request):
             reform_file = tempfile.NamedTemporaryFile(delete=False)
             reform_file.write(reform_text)
             reform_file.close()
+            os.remove(reform_file.name)
             if 'assumpfile' in request.FILES:
                 inmemfile_assumption = request.FILES['assumpfile']
                 assumptions_text = inmemfile_assumption.read()
@@ -235,6 +236,7 @@ def file_input(request):
                 assumptions_file.write(assumptions_text)
                 assumptions_file.close()
                 reform_dict = taxcalc.Calculator.read_json_param_files(reform_file.name, assumptions_file.name, arrays_not_lists=False)
+                os.remove(assumptions_file.name)
             else:
                 assumptions_text = ""
                 reform_dict = taxcalc.Calculator.read_json_param_files(reform_file.name, None, arrays_not_lists=False)

--- a/webapp/apps/test_assets/test_reform.py
+++ b/webapp/apps/test_assets/test_reform.py
@@ -109,3 +109,21 @@ reform_text = """// Title: 2016 Trump Campaign Tax Plan
 // -  Repeal pass-through business tax expenditures
 // -  Corporate tax provisions
 // -  Estate tax provisions"""
+
+regression_sample_reform = """// Assume reform with the following provisions:
+// - adhoc raises in OASDI maximum taxable earnings in 2018, 2019 and 2020,
+//     with _SS_Earnings_c wage indexed in subsequent years
+// - raise personal exemption amount _II_em in 2018, keep it unchanged for
+//     two years and then resume its price indexing in subsequent years
+// - implement a 20% investment income AGI exclusion beginning in 2019
+{
+    "policy": {
+        "_SS_Earnings_c": {"2018": [400000],
+                           "2019": [500000],
+                           "2020": [600000]},
+        "_II_em": {"2018": [8000]},
+        "_II_em_cpi": {"2018": false,
+                       "2020": true},
+        "_ALD_InvInc_ec_rt": {"2019": [0.20]}
+    }
+}"""


### PR DESCRIPTION
@PeterDSteinberg @martinholmer @MattHJensen @hdoupe

I was unable to add a unit test that could help us solve the problem with this file, mainly because it would require saving `puf.csv.gz`. I was, however, able to make a small script that duplicates the behavior that is causing the problem.

```
import json
import celery

import pandas as pd
import taxcalc
from deploy.taxbrain_server.celery_tasks import dropq_task

behavior_params = {u'growdiff_response': {}, u'consumption': {}, u'behavior': {}, u'growdiff_baseline': {}}

user_mods = {u'2019': {u'_SS_Earnings_c': [500000], u'_ALD_InvInc_ec_rt': [0.2]}, u'2020': {u'_SS_Earnings_c': [600000], u'_II_em_cpi': True}, u'2018': {u'_SS_Earnings_c': [400000], u'_II_em_cpi': False, u'_II_em': [8000]}}

puf = pd.read_csv("puf.csv.gz", compression='gzip')

results = dropq_task(0, user_mods, None, behavior_params, puf)
```

You have to run it from the repository root, and `puf.csv.gz` has to also be in the root. This way, you can test out the function and make changes without having to use celery.

Let me know if it helps.

EDIT: You can cause the error by increasing the `year_n` argument, the first argument, to something like 9 or 10.